### PR TITLE
Fix: hydrate multipage dashboard data sources

### DIFF
--- a/dashboard/pages/01_Overview.py
+++ b/dashboard/pages/01_Overview.py
@@ -18,11 +18,12 @@ from components import (
     pnl_histogram,
     rolling_sharpe_chart,
 )
+from ._shared import ensure_data_sources
 
 
 @st.cache_data(show_spinner=False)
 def _get_data() -> Tuple[pd.DataFrame, pd.DataFrame]:
-    data = st.session_state.get("data_sources", {})
+    data = ensure_data_sources()
     trades = data.get("trades", pd.DataFrame()).copy()
     equity = data.get("equity", pd.DataFrame()).copy()
     return trades, equity

--- a/dashboard/pages/02_Markets.py
+++ b/dashboard/pages/02_Markets.py
@@ -8,6 +8,7 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from components import candles_with_trades, download_chart_as_png, volume_profile
+from ._shared import ensure_data_sources
 
 
 @st.cache_data(show_spinner=False)
@@ -54,7 +55,7 @@ st.set_page_config(page_title="Markets · Aurora Desk", page_icon="📈")
 
 st.title("Markets")
 filters = st.session_state.get("filters", {})
-trades = st.session_state.get("data_sources", {}).get("trades", pd.DataFrame())
+trades = ensure_data_sources().get("trades", pd.DataFrame())
 if trades.empty:
     st.info("No trades available; displaying synthetic market data.")
 

--- a/dashboard/pages/03_Workers.py
+++ b/dashboard/pages/03_Workers.py
@@ -9,6 +9,7 @@ import streamlit as st
 from analytics import aggregate_trade_kpis, correlation_matrix, rolling_sharpe
 from components import download_chart_as_png, equity_with_drawdown, risk_return_scatter, rolling_sharpe_chart
 from data_io import save_config
+from ._shared import ensure_data_sources
 
 st.set_page_config(page_title="Workers · Aurora Desk", page_icon="🛠")
 
@@ -18,7 +19,7 @@ if config is None:
     st.warning("Configuration not loaded. Please restart the application.")
     st.stop()
 
-trades = st.session_state.get("data_sources", {}).get("trades", pd.DataFrame())
+trades = ensure_data_sources().get("trades", pd.DataFrame())
 if trades.empty:
     st.info("No trade history. Seed demo data or wait for executions.")
     st.stop()

--- a/dashboard/pages/04_Portfolio_Risk.py
+++ b/dashboard/pages/04_Portfolio_Risk.py
@@ -15,11 +15,12 @@ from analytics import (
     simulate_what_if,
 )
 from components import correlation_heatmap
+from ._shared import ensure_data_sources
 
 st.set_page_config(page_title="Portfolio Risk · Aurora Desk", page_icon="🛡")
 
 st.title("Portfolio & Risk")
-data_sources = st.session_state.get("data_sources", {})
+data_sources = ensure_data_sources()
 trades = data_sources.get("trades", pd.DataFrame())
 equity = data_sources.get("equity", pd.DataFrame())
 if trades.empty:

--- a/dashboard/pages/05_ML_Intelligence.py
+++ b/dashboard/pages/05_ML_Intelligence.py
@@ -11,6 +11,7 @@ from sklearn.metrics import auc, precision_recall_curve, roc_auc_score, roc_curv
 
 from components import download_chart_as_png
 from data_io import DB_LIVE, load_ml_scores
+from ._shared import ensure_data_sources
 
 st.set_page_config(page_title="ML Intelligence · Aurora Desk", page_icon="🧠")
 
@@ -73,7 +74,7 @@ with col2:
 st.subheader("Score gating analysis")
 threshold = st.slider("Minimum probability", 0.0, 1.0, 0.5, step=0.05)
 filtered = worker_df[worker_df["proba_win"] >= threshold]
-trades_df = st.session_state.get("data_sources", {}).get("trades", pd.DataFrame())
+trades_df = ensure_data_sources().get("trades", pd.DataFrame())
 if not trades_df.empty:
     merged = worker_df.merge(trades_df, how="left", on=["worker", "symbol"], suffixes=("", "_trade"))
 else:

--- a/dashboard/pages/06_Orders_Trades.py
+++ b/dashboard/pages/06_Orders_Trades.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
+from ._shared import ensure_data_sources
+
 st.set_page_config(page_title="Orders & Trades · Aurora Desk", page_icon="📜")
 
 st.title("Orders & Trades")
-trades = st.session_state.get("data_sources", {}).get("trades", pd.DataFrame())
+trades = ensure_data_sources().get("trades", pd.DataFrame())
 if trades.empty:
     st.info("No trades to display.")
     st.stop()

--- a/dashboard/pages/07_Logs_Reports.py
+++ b/dashboard/pages/07_Logs_Reports.py
@@ -9,6 +9,7 @@ import streamlit as st
 from fpdf import FPDF
 
 from data_io import LOG_DIR, load_logs
+from ._shared import ensure_data_sources
 
 st.set_page_config(page_title="Logs & Reports · Aurora Desk", page_icon="🗂")
 
@@ -39,7 +40,7 @@ report_dir.mkdir(parents=True, exist_ok=True)
 
 st.subheader("Generate weekly PDF")
 if st.button("Create report"):
-    trades = st.session_state.get("data_sources", {}).get("trades", pd.DataFrame())
+    trades = ensure_data_sources().get("trades", pd.DataFrame())
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Helvetica", "B", 16)

--- a/dashboard/pages/_shared.py
+++ b/dashboard/pages/_shared.py
@@ -1,0 +1,44 @@
+"""Shared helpers for the multipage Streamlit dashboard."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, cast
+
+import pandas as pd
+import streamlit as st
+
+from dashboard.data_io import (
+    DB_LIVE,
+    load_equity,
+    load_ml_scores,
+    load_positions,
+    load_trades,
+    seed_demo_data,
+)
+
+DataSources = Dict[str, pd.DataFrame]
+_REQUIRED_KEYS: Iterable[str] = ("trades", "equity", "positions", "ml_scores")
+
+
+@st.cache_data(show_spinner=False)
+def _load_sources() -> DataSources:
+    """Load core data tables from SQLite, seeding demo rows if needed."""
+
+    seed_demo_data()
+    return {
+        "trades": load_trades(DB_LIVE),
+        "equity": load_equity(DB_LIVE),
+        "positions": load_positions(DB_LIVE),
+        "ml_scores": load_ml_scores(DB_LIVE),
+    }
+
+
+def ensure_data_sources() -> DataSources:
+    """Ensure `st.session_state` exposes the latest cached datasets."""
+
+    data = st.session_state.get("data_sources")
+    if isinstance(data, dict) and all(key in data for key in _REQUIRED_KEYS):
+        return cast(DataSources, data)
+
+    sources = _load_sources()
+    st.session_state["data_sources"] = sources
+    return sources


### PR DESCRIPTION
## Summary
- add a shared multipage helper that seeds demo data and loads the latest trades, equity, positions, and ML scores into `st.session_state`
- update overview, markets, workers, portfolio risk, ML intelligence, orders, and logs pages to rely on the shared loader instead of empty session defaults so visuals populate consistently

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0b5583c50832f8c24968cab9e6f84