### PR TITLE
Feat: add shorting bots, ML pipeline, and pro dashboard

### DIFF
--- a/ai_trader/broker/kraken_client.py
+++ b/ai_trader/broker/kraken_client.py
@@ -22,12 +22,14 @@ class KrakenClient:
         rest_rate_limit: float,
         paper_trading: bool = False,
         paper_starting_equity: float = 10000.0,
+        allow_shorting: bool = False,
     ) -> None:
         self._logger = get_logger(__name__)
         self._paper_trading = paper_trading
         self._base_currency = base_currency
         self._rest_rate_limit = rest_rate_limit
         self._paper_balances: Dict[str, float] = {base_currency: paper_starting_equity}
+        self._allow_shorting = allow_shorting
         self._exchange = ccxt.kraken({
             "apiKey": api_key,
             "secret": api_secret,
@@ -160,7 +162,7 @@ class KrakenClient:
             balances[quote] -= cost
             balances[base] += amount
         else:
-            if balances[base] < amount:
+            if balances[base] < amount and not self._allow_shorting:
                 raise RuntimeError("Insufficient asset for paper sell")
             balances[base] -= amount
             balances[quote] += cost

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -1,30 +1,103 @@
-# Configuration for AI crypto trading bot
+# Production-ready configuration for the AI trading stack
 kraken:
   api_key: "YOUR_KRAKEN_API_KEY"
   api_secret: "YOUR_KRAKEN_API_SECRET"
-  rest_rate_limit: 0.5  # seconds between REST calls
+  rest_rate_limit: 0.5
 
 trading:
   base_currency: "USD"
   symbols:
     - "BTC/USD"
     - "ETH/USD"
-  equity_allocation_percent: 5.0  # percent of equity per trade
-  max_open_positions: 3
+  equity_allocation_percent: 6.0
+  max_open_positions: 4
   paper_trading: true
-  paper_starting_equity: 10000.0
+  paper_starting_equity: 25000.0
+  allow_shorting: true
+  mode: "paper"  # "paper" or "live". Switch via dashboard control then restart the bot.
 
 risk:
-  max_drawdown_percent: 25.0
-  daily_loss_limit_percent: 5.0
-  max_position_duration_minutes: 240
+  max_drawdown_percent: 22.0
+  daily_loss_limit_percent: 4.5
+  max_position_duration_minutes: 180
+
+ml:
+  learning_rate: 0.045
+  regularization: 0.001
+  training_batch_size: 250
+  max_training_rows: 2000
 
 workers:
-  refresh_interval_seconds: 30
-  modules:
-    - "ai_trader.workers.momentum.MomentumWorker"
-    - "ai_trader.workers.mean_reversion.MeanReversionWorker"
+  refresh_interval_seconds: 15
+  definitions:
+    short_momentum:
+      module: "ai_trader.workers.short_momentum.ShortMomentumWorker"
+      enabled: true
+      symbols:
+        - "BTC/USD"
+        - "ETH/USD"
+      parameters:
+        fast_window: 12
+        slow_window: 48
+        momentum_threshold: 0.004
+        warmup_candles: 10
+      risk:
+        leverage: 2.0
+        position_size_pct: 110.0
+        stop_loss_pct: 1.4
+        take_profit_pct: 3.2
+        trailing_stop_pct: 1.0
+    short_mean_reversion:
+      module: "ai_trader.workers.short_mean_reversion.ShortMeanReversionWorker"
+      enabled: true
+      symbols:
+        - "BTC/USD"
+      parameters:
+        band_window: 20
+        band_std_dev: 2.4
+        warmup_candles: 10
+        reversion_threshold: 0.0035
+      risk:
+        leverage: 1.6
+        position_size_pct: 90.0
+        stop_loss_pct: 1.1
+        take_profit_pct: 2.4
+        trailing_stop_pct: 0.75
+    ml_short:
+      module: "ai_trader.workers.ml_short.MLShortWorker"
+      enabled: true
+      symbols:
+        - "BTC/USD"
+        - "ETH/USD"
+      parameters:
+        feature_lookback: 30
+        probability_threshold: 0.62
+        warmup_candles: 10
+      risk:
+        leverage: 1.8
+        position_size_pct: 100.0
+        stop_loss_pct: 1.2
+        take_profit_pct: 2.8
+        trailing_stop_pct: 0.9
+
+researcher:
+  module: "ai_trader.workers.researcher.MarketResearchWorker"
+  enabled: true
+  symbols:
+    - "BTC/USD"
+    - "ETH/USD"
+  parameters:
+    warmup_candles: 10
+    feature_windows:
+      - 5
+      - 14
+      - 30
+    timeframe: "1m"
+    log_every_n_snapshots: 1
+    volatility_window: 20
 
 dashboard:
   host: "0.0.0.0"
   port: 8501
+  refresh_interval_seconds: 5
+  default_symbol: "BTC/USD"

--- a/ai_trader/services/ml_pipeline.py
+++ b/ai_trader/services/ml_pipeline.py
@@ -1,0 +1,172 @@
+"""Lightweight online ML pipeline for trading signals."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class FeatureVector:
+    """Structured representation of engineered features."""
+
+    symbol: str
+    timestamp: str
+    features: List[float]
+    label: Optional[float]
+
+
+class OnlineLogisticModel:
+    """Simple online logistic regression for streaming updates."""
+
+    def __init__(self, feature_dim: int, learning_rate: float, regularization: float) -> None:
+        self.feature_dim = feature_dim
+        self.learning_rate = learning_rate
+        self.regularization = regularization
+        self.weights = np.zeros(feature_dim, dtype=float)
+        self.bias = 0.0
+
+    def predict(self, features: Sequence[float]) -> float:
+        vector = np.asarray(features, dtype=float)
+        z = float(np.dot(self.weights, vector) + self.bias)
+        z = max(min(z, 35.0), -35.0)  # numerical stability
+        return 1.0 / (1.0 + math.exp(-z))
+
+    def update(self, features: Sequence[float], label: float) -> None:
+        vector = np.asarray(features, dtype=float)
+        prediction = self.predict(vector)
+        error = prediction - label
+        self.weights -= self.learning_rate * (error * vector + self.regularization * self.weights)
+        self.bias -= self.learning_rate * error
+
+
+class MLPipeline:
+    """Persist features and keep models updated for downstream workers."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        feature_keys: Sequence[str],
+        learning_rate: float,
+        regularization: float,
+        batch_size: int,
+        max_training_rows: int,
+    ) -> None:
+        self._db_path = db_path
+        self._feature_keys = list(feature_keys)
+        self._learning_rate = learning_rate
+        self._regularization = regularization
+        self._batch_size = batch_size
+        self._max_training_rows = max_training_rows
+        self._models: Dict[str, OnlineLogisticModel] = {}
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ml_models (
+                    symbol TEXT PRIMARY KEY,
+                    weights TEXT NOT NULL,
+                    bias REAL NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._db_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _feature_vector_from_row(self, row: sqlite3.Row) -> FeatureVector:
+        payload = json.loads(row["features_json"])
+        features = [float(payload.get(key, 0.0)) for key in self._feature_keys]
+        label = row["label"]
+        label_value = float(label) if label is not None else None
+        return FeatureVector(symbol=row["symbol"], timestamp=row["timestamp"], features=features, label=label_value)
+
+    def fetch_recent_features(self, symbol: str, limit: int = 500) -> List[FeatureVector]:
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT timestamp, symbol, features_json, label
+                FROM market_features
+                WHERE symbol = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """,
+                (symbol, limit),
+            )
+            rows = cursor.fetchall()
+        return [self._feature_vector_from_row(row) for row in rows]
+
+    def latest_feature(self, symbol: str) -> Optional[FeatureVector]:
+        features = self.fetch_recent_features(symbol, limit=1)
+        return features[0] if features else None
+
+    def _load_model(self, symbol: str, feature_dim: int) -> OnlineLogisticModel:
+        model = self._models.get(symbol)
+        if model:
+            return model
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT weights, bias FROM ml_models WHERE symbol = ?", (symbol,)).fetchone()
+        if row:
+            weights = np.asarray(json.loads(row["weights"]), dtype=float)
+            bias = float(row["bias"])
+            model = OnlineLogisticModel(feature_dim, self._learning_rate, self._regularization)
+            if len(weights) == feature_dim:
+                model.weights = weights
+            model.bias = bias
+        else:
+            model = OnlineLogisticModel(feature_dim, self._learning_rate, self._regularization)
+        self._models[symbol] = model
+        return model
+
+    def _persist_model(self, symbol: str, model: OnlineLogisticModel) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ml_models(symbol, weights, bias, updated_at)
+                VALUES(?, ?, ?, datetime('now'))
+                ON CONFLICT(symbol) DO UPDATE SET
+                    weights = excluded.weights,
+                    bias = excluded.bias,
+                    updated_at = excluded.updated_at
+                """,
+                (symbol, json.dumps(model.weights.tolist()), model.bias),
+            )
+            conn.commit()
+
+    def train(self, symbol: str) -> None:
+        dataset = self.fetch_recent_features(symbol, limit=self._max_training_rows)
+        if not dataset:
+            return
+        model = self._load_model(symbol, len(self._feature_keys))
+        batch = list(reversed(dataset[: self._batch_size]))
+        for vector in batch:
+            if vector.label is None:
+                continue
+            model.update(vector.features, vector.label)
+        self._persist_model(symbol, model)
+
+    def predict(self, symbol: str, features: Sequence[float]) -> float:
+        model = self._load_model(symbol, len(features))
+        return model.predict(features)
+
+    @property
+    def feature_keys(self) -> Sequence[str]:
+        return self._feature_keys

--- a/ai_trader/services/worker_loader.py
+++ b/ai_trader/services/worker_loader.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import importlib
-from typing import Iterable, List, Sequence
+import inspect
+from typing import Any, Dict, List, Sequence, Tuple
 
 from ..services.logging import get_logger
 
@@ -11,18 +12,42 @@ from ..services.logging import get_logger
 class WorkerLoader:
     """Load worker classes defined in configuration."""
 
-    def __init__(self, worker_paths: Sequence[str], symbols: Sequence[str]) -> None:
-        self._worker_paths = worker_paths
+    def __init__(self, worker_config: Dict[str, Any], symbols: Sequence[str]) -> None:
+        self._worker_config = worker_config
         self._symbols = list(symbols)
         self._logger = get_logger(__name__)
 
-    def load(self) -> List[object]:
+    def load(self, shared_services: Dict[str, Any]) -> Tuple[List[object], List[object]]:
         workers: List[object] = []
-        for dotted_path in self._worker_paths:
+        researchers: List[object] = []
+        definitions = self._worker_config.get("definitions", {})
+        for worker_name, definition in definitions.items():
+            if not definition.get("enabled", True):
+                self._logger.info("Worker %s disabled via configuration", worker_name)
+                continue
+            dotted_path = definition.get("module")
+            if not dotted_path:
+                self._logger.warning("Worker %s missing module path", worker_name)
+                continue
             module_name, class_name = dotted_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             worker_cls = getattr(module, class_name)
-            worker = worker_cls(symbols=self._symbols)
-            workers.append(worker)
-            self._logger.info("Worker %s loaded", dotted_path)
-        return workers
+            kwargs: Dict[str, Any] = {}
+            symbols = definition.get("symbols", self._symbols)
+            params = definition.get("parameters", {})
+            risk_cfg = definition.get("risk", {})
+            signature = inspect.signature(worker_cls)
+            for param_name in signature.parameters:
+                if param_name == "symbols":
+                    kwargs[param_name] = symbols
+                elif param_name == "config":
+                    kwargs[param_name] = params
+                elif param_name == "risk_config":
+                    kwargs[param_name] = risk_cfg
+                elif param_name in shared_services:
+                    kwargs[param_name] = shared_services[param_name]
+            worker = worker_cls(**kwargs)
+            target = researchers if getattr(worker, "is_researcher", False) else workers
+            target.append(worker)
+            self._logger.info("Worker %s loaded (%s)", worker.name, dotted_path)
+        return workers, researchers

--- a/ai_trader/workers/base.py
+++ b/ai_trader/workers/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import deque
-from typing import Deque, Dict, Iterable, List, Optional
+from typing import Any, Deque, Dict, Iterable, List, Optional
 
 from ..services.types import MarketSnapshot, OpenPosition, TradeIntent
 
@@ -14,20 +14,72 @@ class BaseWorker(ABC):
 
     name: str = "BaseWorker"
     emoji: str = "🤖"
+    is_researcher: bool = False
 
-    def __init__(self, symbols: Iterable[str], lookback: int = 50) -> None:
+    def __init__(
+        self,
+        symbols: Iterable[str],
+        lookback: int = 50,
+        config: Optional[Dict[str, Any]] = None,
+        risk_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
         self.symbols: List[str] = list(symbols)
         self.lookback = lookback
         self.price_history: Dict[str, Deque[float]] = {
             symbol: deque(maxlen=lookback) for symbol in self.symbols
         }
         self.active: bool = True
+        self.config: Dict[str, Any] = config or {}
+        self.risk_config: Dict[str, Any] = risk_config or {}
+        self.warmup_candles: int = max(1, int(self.config.get("warmup_candles", 10)))
+        self.position_size_pct: float = float(self.risk_config.get("position_size_pct", 100.0))
+        self.leverage: float = float(self.risk_config.get("leverage", 1.0))
+        self.stop_loss_pct: float = float(self.risk_config.get("stop_loss_pct", 0.0))
+        self.take_profit_pct: float = float(self.risk_config.get("take_profit_pct", 0.0))
+        self.trailing_stop_pct: float = float(self.risk_config.get("trailing_stop_pct", 0.0))
+        self._latest_signals: Dict[str, Optional[str]] = {symbol: None for symbol in self.symbols}
+        self._state: Dict[str, Dict[str, Any]] = {}
 
     def update_history(self, snapshot: MarketSnapshot) -> None:
         for symbol, price in snapshot.prices.items():
             if symbol not in self.price_history:
                 self.price_history[symbol] = deque(maxlen=self.lookback)
             self.price_history[symbol].append(price)
+
+    def is_ready(self, symbol: str) -> bool:
+        """Return True when the worker has enough candles to act."""
+
+        history = self.price_history.get(symbol, [])
+        return len(history) >= self.warmup_candles
+
+    def update_signal_state(
+        self, symbol: str, signal: Optional[str], indicators: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Persist the latest signal and indicator snapshot for dashboards."""
+
+        self._latest_signals[symbol] = signal
+        state = self._state.setdefault(symbol, {})
+        state["last_signal"] = signal
+        if indicators:
+            state.setdefault("indicators", {}).update(indicators)
+        state["leverage"] = self.leverage
+        state["position_size_pct"] = self.position_size_pct
+        state["stop_loss_pct"] = self.stop_loss_pct
+        state["take_profit_pct"] = self.take_profit_pct
+        state["trailing_stop_pct"] = self.trailing_stop_pct
+
+    def get_state_snapshot(self, symbol: str) -> Dict[str, Any]:
+        """Return the last-known state for a symbol."""
+
+        snapshot = dict(self._state.get(symbol, {}))
+        snapshot.setdefault("status", "ready" if self.is_ready(symbol) else "warmup")
+        snapshot.setdefault("last_signal", self._latest_signals.get(symbol))
+        return snapshot
+
+    def get_all_state_snapshots(self) -> Dict[str, Dict[str, Any]]:
+        """Expose the entire state dictionary for persistence."""
+
+        return {symbol: self.get_state_snapshot(symbol) for symbol in self.symbols}
 
     @abstractmethod
     async def evaluate_signal(self, snapshot: MarketSnapshot) -> Dict[str, str]:
@@ -49,3 +101,14 @@ class BaseWorker(ABC):
 
     def activate(self) -> None:
         self.active = True
+
+    async def observe(
+        self,
+        snapshot: MarketSnapshot,
+        equity_metrics: Optional[Dict[str, Any]] = None,
+        open_positions: Optional[List[OpenPosition]] = None,
+    ) -> None:
+        """Optional hook for researcher-style workers."""
+
+        # No-op by default. Sub-classes may override.
+        _ = (snapshot, equity_metrics, open_positions)

--- a/ai_trader/workers/ml_short.py
+++ b/ai_trader/workers/ml_short.py
@@ -1,0 +1,122 @@
+"""Machine-learning assisted shorting worker."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .base import BaseWorker
+from ..services.ml_pipeline import MLPipeline
+from ..services.types import MarketSnapshot, OpenPosition, TradeIntent
+
+
+class MLShortWorker(BaseWorker):
+    """Uses an online logistic model to size short entries."""
+
+    name = "ML Short Alpha"
+    emoji = "🧠"
+
+    def __init__(
+        self,
+        symbols,
+        pipeline: MLPipeline,
+        config: Optional[Dict] = None,
+        risk_config: Optional[Dict] = None,
+    ) -> None:
+        self._pipeline = pipeline
+        self.feature_lookback = int((config or {}).get("feature_lookback", 30))
+        lookback = max(self.feature_lookback * 2, int((config or {}).get("lookback", self.feature_lookback * 2)))
+        super().__init__(symbols=symbols, lookback=lookback, config=config, risk_config=risk_config)
+        self.threshold = float((config or {}).get("probability_threshold", 0.6))
+        self.cover_threshold = float((config or {}).get("cover_threshold", 0.48))
+        self._last_probabilities: Dict[str, float] = {}
+
+    async def evaluate_signal(self, snapshot: MarketSnapshot) -> Dict[str, str]:
+        self.update_history(snapshot)
+        signals: Dict[str, str] = {}
+        for symbol in self.symbols:
+            feature_vector = self._pipeline.latest_feature(symbol)
+            if feature_vector is None:
+                self.update_signal_state(symbol, None, {"status": "awaiting-features"})
+                continue
+            self._pipeline.train(symbol)
+            probability = self._pipeline.predict(symbol, feature_vector.features)
+            self._last_probabilities[symbol] = probability
+            signal: Optional[str] = None
+            if probability >= self.threshold and self.is_ready(symbol):
+                signal = "sell"
+            elif probability <= self.cover_threshold:
+                signal = "buy"
+            indicator_state = {
+                "probability": probability,
+                "label": feature_vector.label,
+                "features": dict(zip(self._pipeline.feature_keys, feature_vector.features)),
+            }
+            self.update_signal_state(symbol, signal, indicator_state)
+            if signal:
+                signals[symbol] = signal
+        return signals
+
+    async def generate_trade(
+        self,
+        symbol: str,
+        signal: Optional[str],
+        snapshot: MarketSnapshot,
+        equity_per_trade: float,
+        existing_position: Optional[OpenPosition] = None,
+    ) -> Optional[TradeIntent]:
+        price = snapshot.prices.get(symbol)
+        if price is None:
+            return None
+
+        probability = self._last_probabilities.get(symbol, 0.5)
+        if existing_position is None:
+            if signal != "sell" or not self.is_ready(symbol):
+                return None
+            cash = equity_per_trade * (self.position_size_pct / 100)
+            if cash <= 0:
+                return None
+            confidence = min(1.0, max(0.0, probability - 0.5))
+            return TradeIntent(
+                worker=self.name,
+                action="OPEN",
+                symbol=symbol,
+                side="sell",
+                cash_spent=cash * self.leverage,
+                entry_price=price,
+                confidence=confidence,
+            )
+
+        close_signal = False
+        reason = ""
+        if signal == "buy":
+            close_signal = True
+            reason = "prob-revert"
+        elif probability <= self.cover_threshold:
+            close_signal = True
+            reason = "prob-floor"
+
+        if self.stop_loss_pct:
+            stop_price = existing_position.entry_price * (1 + self.stop_loss_pct / 100)
+            if price >= stop_price:
+                close_signal = True
+                reason = "stop"
+        if self.take_profit_pct:
+            target_price = existing_position.entry_price * (1 - self.take_profit_pct / 100)
+            if price <= target_price:
+                close_signal = True
+                reason = "target"
+
+        if close_signal:
+            self.update_signal_state(symbol, f"close:{reason}")
+            return TradeIntent(
+                worker=self.name,
+                action="CLOSE",
+                symbol=symbol,
+                side="buy",
+                cash_spent=existing_position.cash_spent,
+                entry_price=existing_position.entry_price,
+                exit_price=price,
+                confidence=probability,
+            )
+
+        return None

--- a/ai_trader/workers/researcher.py
+++ b/ai_trader/workers/researcher.py
@@ -1,0 +1,133 @@
+"""Non-trading researcher bot that feeds the ML pipeline."""
+
+from __future__ import annotations
+
+import math
+from statistics import fmean, pstdev
+from typing import Dict, Iterable, List, Optional
+
+from .base import BaseWorker
+from ..services.ml_pipeline import MLPipeline
+from ..services.trade_log import TradeLog
+from ..services.types import MarketSnapshot, OpenPosition
+
+
+class MarketResearchWorker(BaseWorker):
+    """Observes markets, engineers features, and persists research data."""
+
+    name = "Research Sentinel"
+    emoji = "🔬"
+    is_researcher = True
+
+    def __init__(
+        self,
+        symbols,
+        trade_log: TradeLog,
+        pipeline: MLPipeline,
+        config: Optional[Dict] = None,
+    ) -> None:
+        lookback = max(200, int((config or {}).get("lookback", 200)))
+        super().__init__(symbols=symbols, lookback=lookback, config=config)
+        self._trade_log = trade_log
+        self._pipeline = pipeline
+        cfg = config or {}
+        self.feature_windows: List[int] = list(cfg.get("feature_windows", [5, 14, 30]))
+        self.timeframe: str = cfg.get("timeframe", "1m")
+        self.log_every_n = max(1, int(cfg.get("log_every_n_snapshots", 1)))
+        self.volatility_window = max(5, int(cfg.get("volatility_window", 20)))
+        self._snapshot_counter = 0
+
+    async def evaluate_signal(self, snapshot: MarketSnapshot) -> Dict[str, str]:
+        # Researcher does not emit trade signals but we keep interface parity.
+        await self.observe(snapshot)
+        return {}
+
+    async def generate_trade(self, *args, **kwargs):  # type: ignore[override]
+        return None
+
+    async def observe(
+        self,
+        snapshot: MarketSnapshot,
+        equity_metrics: Optional[Dict[str, float]] = None,
+        open_positions: Optional[List[OpenPosition]] = None,
+    ) -> None:
+        self.update_history(snapshot)
+        self._snapshot_counter += 1
+        if self._snapshot_counter % self.log_every_n != 0:
+            return
+        for symbol in self.symbols:
+            history = snapshot.history.get(symbol, [])
+            if len(history) < max(max(self.feature_windows), self.warmup_candles) + 5:
+                continue
+            features = self._build_features(history)
+            label = 1.0 if features.get("return_5", 0.0) < 0 and features.get("return_1", 0.0) < 0 else 0.0
+            payload = {
+                "symbol": symbol,
+                "timeframe": self.timeframe,
+                "price": history[-1],
+                "features": features,
+                "label": label,
+            }
+            self._trade_log.record_market_features(payload)
+            self._pipeline.train(symbol)
+            self.update_signal_state(symbol, None, {"features": features, "label": label})
+
+    def _build_features(self, history: List[float]) -> Dict[str, float]:
+        latest = history[-1]
+        prev = history[-2]
+        returns = [math.log(history[idx] / history[idx - 1]) for idx in range(1, len(history)) if history[idx - 1] > 0]
+        return_1 = math.log(latest / prev) if prev > 0 else 0.0
+        return_5 = math.log(latest / history[-6]) if len(history) > 5 and history[-6] > 0 else return_1
+        return_15 = math.log(latest / history[-16]) if len(history) > 15 and history[-16] > 0 else return_5
+        volatility = pstdev(returns[-self.volatility_window :]) if len(returns) >= self.volatility_window else pstdev(returns) if returns else 0.0
+        ema_fast = self._ema(history, 12)
+        ema_slow = self._ema(history, 26)
+        macd = ema_fast - ema_slow
+        signal = self._ema(history, 9)
+        macd_hist = macd - signal
+        rsi = self._rsi(history, period=14)
+        mean_price = fmean(history[-30:]) if len(history) >= 30 else fmean(history)
+        std_dev = pstdev(history[-30:]) if len(history) >= 30 else pstdev(history) if len(history) > 1 else 0.0
+        zscore = (latest - mean_price) / std_dev if std_dev else 0.0
+        features = {
+            "return_1": return_1,
+            "return_5": return_5,
+            "return_15": return_15,
+            "volatility": volatility,
+            "ema_fast": ema_fast,
+            "ema_slow": ema_slow,
+            "macd": macd,
+            "macd_hist": macd_hist,
+            "rsi": rsi,
+            "zscore": zscore,
+        }
+        return features
+
+    @staticmethod
+    def _ema(history: Iterable[float], window: int) -> float:
+        prices = list(history[-window * 3 :]) if window else list(history)
+        if not prices:
+            return 0.0
+        k = 2 / (window + 1)
+        ema = prices[0]
+        for price in prices[1:]:
+            ema = price * k + ema * (1 - k)
+        return ema
+
+    @staticmethod
+    def _rsi(history: List[float], period: int = 14) -> float:
+        if len(history) < period + 1:
+            return 50.0
+        gains = []
+        losses = []
+        for idx in range(1, period + 1):
+            delta = history[-idx] - history[-idx - 1]
+            if delta >= 0:
+                gains.append(delta)
+            else:
+                losses.append(abs(delta))
+        avg_gain = sum(gains) / period if gains else 0.0
+        avg_loss = sum(losses) / period if losses else 1e-9
+        rs = avg_gain / avg_loss if avg_loss else 0.0
+        rsi = 100 - (100 / (1 + rs))
+        return max(0.0, min(100.0, rsi))

--- a/ai_trader/workers/short_mean_reversion.py
+++ b/ai_trader/workers/short_mean_reversion.py
@@ -1,0 +1,154 @@
+"""Mean reversion short specialist."""
+
+from __future__ import annotations
+
+from statistics import fmean, pstdev
+from typing import Dict, Optional
+
+from .base import BaseWorker
+from ..services.types import MarketSnapshot, OpenPosition, TradeIntent
+
+
+class ShortMeanReversionWorker(BaseWorker):
+    """Fades euphoric spikes expecting price to mean revert."""
+
+    name = "Reversion Raider"
+    emoji = "🔄"
+
+    def __init__(
+        self,
+        symbols,
+        config: Optional[Dict] = None,
+        risk_config: Optional[Dict] = None,
+    ) -> None:
+        band_window = int((config or {}).get("band_window", 20))
+        lookback = max(band_window * 3, int((config or {}).get("lookback", band_window * 3)))
+        super().__init__(symbols=symbols, lookback=lookback, config=config, risk_config=risk_config)
+        self.band_window = band_window
+        self.band_std_dev = float((config or {}).get("band_std_dev", 2.2))
+        self.reversion_threshold = float((config or {}).get("reversion_threshold", 0.003))
+        self._position_tracker: Dict[str, Dict[str, float]] = {}
+
+    async def evaluate_signal(self, snapshot: MarketSnapshot) -> Dict[str, str]:
+        self.update_history(snapshot)
+        signals: Dict[str, str] = {}
+        for symbol in self.symbols:
+            history = list(self.price_history.get(symbol, []))
+            if len(history) < max(self.band_window, self.warmup_candles):
+                self.update_signal_state(symbol, None, {"status": "warmup"})
+                continue
+            window = history[-self.band_window :]
+            mid = fmean(window)
+            std_dev = pstdev(window) if len(window) > 1 else 0.0
+            upper_band = mid + std_dev * self.band_std_dev
+            lower_band = mid - std_dev * self.band_std_dev
+            last_price = history[-1]
+            distance = (last_price - mid) / mid if mid else 0.0
+            signal: Optional[str] = None
+
+            if not self.is_ready(symbol):
+                self.update_signal_state(
+                    symbol,
+                    signal,
+                    {
+                        "status": "warmup",
+                        "mid": mid,
+                        "upper_band": upper_band,
+                        "lower_band": lower_band,
+                        "distance": distance,
+                    },
+                )
+                continue
+
+            if last_price > upper_band * (1 + self.reversion_threshold):
+                signal = "sell"
+            elif last_price <= mid or last_price < upper_band * (1 - self.reversion_threshold):
+                signal = "buy"
+
+            indicators = {
+                "mid": mid,
+                "upper_band": upper_band,
+                "lower_band": lower_band,
+                "price": last_price,
+                "distance": distance,
+            }
+            self.update_signal_state(symbol, signal, indicators)
+            if signal:
+                signals[symbol] = signal
+        return signals
+
+    async def generate_trade(
+        self,
+        symbol: str,
+        signal: Optional[str],
+        snapshot: MarketSnapshot,
+        equity_per_trade: float,
+        existing_position: Optional[OpenPosition] = None,
+    ) -> Optional[TradeIntent]:
+        price = snapshot.prices.get(symbol)
+        if price is None:
+            return None
+
+        tracker = self._position_tracker.setdefault(symbol, {"best_price": price})
+
+        if existing_position is None:
+            if signal != "sell" or not self.is_ready(symbol):
+                return None
+            cash = equity_per_trade * (self.position_size_pct / 100)
+            if cash <= 0:
+                return None
+            tracker["best_price"] = price
+            tracker["stop_price"] = price * (1 + self.stop_loss_pct / 100) if self.stop_loss_pct else None
+            tracker["mean_price"] = self._state.get(symbol, {}).get("indicators", {}).get("mid", price)
+            return TradeIntent(
+                worker=self.name,
+                action="OPEN",
+                symbol=symbol,
+                side="sell",
+                cash_spent=cash * self.leverage,
+                entry_price=price,
+                confidence=0.65,
+            )
+
+        tracker["best_price"] = min(tracker.get("best_price", price), price)
+        if self.take_profit_pct:
+            tracker["target_price"] = existing_position.entry_price * (1 - self.take_profit_pct / 100)
+        else:
+            mean_price = tracker.get("mean_price") or existing_position.entry_price
+            tracker["target_price"] = mean_price
+
+        stop_price = tracker.get("stop_price") or existing_position.entry_price * (1 + self.stop_loss_pct / 100)
+        target_price = tracker.get("target_price")
+        trailing_price = None
+        if self.trailing_stop_pct:
+            trailing_price = tracker["best_price"] * (1 + self.trailing_stop_pct / 100)
+
+        should_close = False
+        reason = ""
+        if signal == "buy":
+            should_close = True
+            reason = "mean-hit"
+        if target_price and price <= target_price:
+            should_close = True
+            reason = reason or "target"
+        if stop_price and price >= stop_price:
+            should_close = True
+            reason = "stop"
+        if trailing_price and price >= trailing_price:
+            should_close = True
+            reason = reason or "trail"
+
+        if should_close:
+            self.update_signal_state(symbol, f"close:{reason}")
+            return TradeIntent(
+                worker=self.name,
+                action="CLOSE",
+                symbol=symbol,
+                side="buy",
+                cash_spent=existing_position.cash_spent,
+                entry_price=existing_position.entry_price,
+                exit_price=price,
+                confidence=0.7,
+            )
+
+        return None

--- a/ai_trader/workers/short_momentum.py
+++ b/ai_trader/workers/short_momentum.py
@@ -1,0 +1,176 @@
+"""Momentum-driven short bias worker."""
+
+from __future__ import annotations
+
+import math
+from statistics import pstdev
+from typing import Dict, Optional
+
+from .base import BaseWorker
+from ..services.types import MarketSnapshot, OpenPosition, TradeIntent
+
+
+class ShortMomentumWorker(BaseWorker):
+    """Shorts accelerating breakdowns confirmed by momentum and volatility."""
+
+    name = "Velocity Short"
+    emoji = "🩳"
+
+    def __init__(
+        self,
+        symbols,
+        config: Optional[Dict] = None,
+        risk_config: Optional[Dict] = None,
+    ) -> None:
+        self.fast_window = int((config or {}).get("fast_window", 12))
+        self.slow_window = int((config or {}).get("slow_window", 48))
+        lookback = max(self.slow_window * 3, int((config or {}).get("lookback", self.slow_window * 3)))
+        super().__init__(symbols=symbols, lookback=lookback, config=config, risk_config=risk_config)
+        self.momentum_threshold = float((config or {}).get("momentum_threshold", 0.004))
+        self._position_tracker: Dict[str, Dict[str, float]] = {}
+
+    @staticmethod
+    def _ema(prices: list[float], window: int) -> float:
+        if not prices:
+            return 0.0
+        k = 2 / (window + 1)
+        ema = prices[0]
+        for price in prices[1:]:
+            ema = price * k + ema * (1 - k)
+        return ema
+
+    async def evaluate_signal(self, snapshot: MarketSnapshot) -> Dict[str, str]:
+        self.update_history(snapshot)
+        signals: Dict[str, str] = {}
+        for symbol in self.symbols:
+            history = list(self.price_history.get(symbol, []))
+            if len(history) < max(self.slow_window, self.warmup_candles):
+                self.update_signal_state(symbol, None, {"status": "warmup"})
+                continue
+
+            fast = self._ema(history[-self.fast_window * 2 :], self.fast_window)
+            slow = self._ema(history[-self.slow_window * 2 :], self.slow_window)
+            last_price = history[-1]
+            returns = [math.log(history[idx] / history[idx - 1]) for idx in range(1, len(history)) if history[idx - 1] > 0]
+            vol = pstdev(returns[-self.slow_window :]) if len(returns) >= self.slow_window else 0.0
+            momentum = slow - fast
+            threshold = abs(slow) * self.momentum_threshold
+            signal: Optional[str] = None
+
+            if not self.is_ready(symbol):
+                state = {
+                    "status": "warmup",
+                    "fast_ema": fast,
+                    "slow_ema": slow,
+                    "momentum": momentum,
+                    "volatility": vol,
+                    "price": last_price,
+                }
+                self.update_signal_state(symbol, signal, state)
+                continue
+
+            if fast < slow and abs(momentum) > threshold and last_price < slow:
+                signal = "sell"
+            elif fast > slow * (1.002):
+                signal = "buy"
+
+            indicators = {
+                "fast_ema": fast,
+                "slow_ema": slow,
+                "momentum": momentum,
+                "volatility": vol,
+                "price": last_price,
+                "threshold": threshold,
+            }
+            self.update_signal_state(symbol, signal, indicators)
+            if signal:
+                signals[symbol] = signal
+        return signals
+
+    async def generate_trade(
+        self,
+        symbol: str,
+        signal: Optional[str],
+        snapshot: MarketSnapshot,
+        equity_per_trade: float,
+        existing_position: Optional[OpenPosition] = None,
+    ) -> Optional[TradeIntent]:
+        price = snapshot.prices.get(symbol)
+        if price is None:
+            return None
+
+        tracker = self._position_tracker.setdefault(
+            symbol,
+            {
+                "best_price": price,
+            },
+        )
+
+        if existing_position is None:
+            if signal != "sell" or not self.is_ready(symbol):
+                return None
+            cash = equity_per_trade * (self.position_size_pct / 100)
+            cash = max(cash, 0.0)
+            if cash == 0:
+                return None
+            tracker["best_price"] = price
+            tracker["stop_price"] = price * (1 + self.stop_loss_pct / 100) if self.stop_loss_pct else None
+            tracker["target_price"] = price * (1 - self.take_profit_pct / 100) if self.take_profit_pct else None
+            tracker["trailing"] = price * (1 + self.trailing_stop_pct / 100) if self.trailing_stop_pct else None
+            return TradeIntent(
+                worker=self.name,
+                action="OPEN",
+                symbol=symbol,
+                side="sell",
+                cash_spent=cash * self.leverage,
+                entry_price=price,
+                confidence=min(1.0, max(0.0, abs(tracker.get("stop_price", price) - price) / price)),
+            )
+
+        # Position management for an open short.
+        tracker["best_price"] = min(tracker.get("best_price", price), price)
+        if self.trailing_stop_pct:
+            tracker["trailing"] = tracker["best_price"] * (1 + self.trailing_stop_pct / 100)
+
+        stop_price = (
+            existing_position.entry_price * (1 + self.stop_loss_pct / 100)
+            if self.stop_loss_pct
+            else tracker.get("stop_price")
+        )
+        target_price = (
+            existing_position.entry_price * (1 - self.take_profit_pct / 100)
+            if self.take_profit_pct
+            else tracker.get("target_price")
+        )
+        trailing_price = tracker.get("trailing")
+
+        close_signal = False
+        reason = ""
+        if signal == "buy":
+            close_signal = True
+            reason = "reverse"
+        if stop_price and price >= stop_price:
+            close_signal = True
+            reason = "stop"
+        if target_price and price <= target_price:
+            close_signal = True
+            reason = reason or "target"
+        if trailing_price and price >= trailing_price:
+            close_signal = True
+            reason = reason or "trail"
+
+        if close_signal:
+            tracker["best_price"] = price
+            self.update_signal_state(symbol, f"close:{reason}")
+            return TradeIntent(
+                worker=self.name,
+                action="CLOSE",
+                symbol=symbol,
+                side="buy",
+                cash_spent=existing_position.cash_spent,
+                entry_price=existing_position.entry_price,
+                exit_price=price,
+                confidence=0.7,
+            )
+
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.2.2
 plotly==5.20.0
 streamlit==1.32.0
 colorama==0.4.6
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- add three advanced short-selling workers plus a market researcher bot wired into a shared online ML pipeline
- upgrade orchestration, risk logging, and config persistence to support per-bot controls, kill switch flags, and short-enabled paper trading
- rebuild the Streamlit dashboard with live equity metrics, strategy cards, interactive charts, and control panels tied to config.yaml and SQLite state

## Testing
- python -m compileall ai_trader

------
https://chatgpt.com/codex/tasks/task_e_68d0dae3528c832fabd8adb98b746805