### PR TITLE
Add online ML service with dashboard telemetry

### DIFF
--- a/ai_trader/broker/websocket_manager.py
+++ b/ai_trader/broker/websocket_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections import deque
+from datetime import datetime, timedelta
 from typing import Deque, Dict, List
 
 import websockets
@@ -16,7 +17,7 @@ from ..services.types import MarketSnapshot
 class KrakenWebsocketManager:
     """Maintain live price snapshots from Kraken's public WebSocket."""
 
-    def __init__(self, symbols: List[str], history: int = 120) -> None:
+    def __init__(self, symbols: List[str], history: int = 120, candle_interval_seconds: int = 60) -> None:
         self._symbols = symbols
         self._history = history
         self._url = "wss://ws.kraken.com/"
@@ -24,6 +25,12 @@ class KrakenWebsocketManager:
         self._price_history: Dict[str, Deque[float]] = {
             symbol: deque(maxlen=history) for symbol in symbols
         }
+        self._ohlcv_history: Dict[str, Deque[dict[str, float]]] = {
+            symbol: deque(maxlen=history) for symbol in symbols
+        }
+        self._current_bars: Dict[str, dict[str, float]] = {}
+        self._bar_interval = timedelta(seconds=max(1, candle_interval_seconds))
+        self._last_volume_totals: Dict[str, float] = {}
         self._logger = get_logger(__name__)
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
@@ -76,14 +83,77 @@ class KrakenWebsocketManager:
         pair = data[-1]
         if isinstance(pair, str) and pair.startswith("XBT/"):
             pair = pair.replace("XBT", "BTC")
-        price = payload.get("c", [None])[0]
-        if price is None:
+        price_raw = payload.get("c", [None])[0]
+        if price_raw is None:
             return
-        price = float(price)
+        price = float(price_raw)
         self._latest_prices[pair] = price
         history = self._price_history.setdefault(pair, deque(maxlen=self._history))
         history.append(price)
+        now = datetime.utcnow()
+        volume_fields = payload.get("v", [None, None])
+        volume_total = float(volume_fields[1]) if isinstance(volume_fields, list) and len(volume_fields) > 1 else 0.0
+        previous_total = self._last_volume_totals.get(pair)
+        volume_delta = max(0.0, volume_total - previous_total) if previous_total is not None else 0.0
+        self._last_volume_totals[pair] = volume_total
+        self._update_candle(pair, price, volume_delta, now)
 
     def latest_snapshot(self) -> MarketSnapshot:
+        self._finalize_stale_bars()
         history = {symbol: list(self._price_history.get(symbol, [])) for symbol in self._symbols}
-        return MarketSnapshot(prices=dict(self._latest_prices), history=history)
+        candles = {symbol: list(self._ohlcv_history.get(symbol, [])) for symbol in self._symbols}
+        return MarketSnapshot(prices=dict(self._latest_prices), history=history, candles=candles)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _update_candle(self, symbol: str, price: float, volume: float, timestamp: datetime) -> None:
+        bar = self._current_bars.get(symbol)
+        if bar is None:
+            bar = {
+                "open": price,
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": volume,
+                "start": timestamp,
+            }
+            self._current_bars[symbol] = bar
+            return
+
+        interval_elapsed = (timestamp - bar["start"]) >= self._bar_interval
+        if interval_elapsed:
+            finalized = {key: float(bar[key]) for key in ("open", "high", "low", "close", "volume")}
+            history = self._ohlcv_history.setdefault(symbol, deque(maxlen=self._history))
+            history.append(finalized)
+            bar = {
+                "open": bar["close"],
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": volume,
+                "start": timestamp,
+            }
+            self._current_bars[symbol] = bar
+            return
+
+        bar["high"] = max(bar["high"], price)
+        bar["low"] = min(bar["low"], price)
+        bar["close"] = price
+        bar["volume"] = bar.get("volume", 0.0) + volume
+
+    def _finalize_stale_bars(self) -> None:
+        now = datetime.utcnow()
+        for symbol, bar in list(self._current_bars.items()):
+            if not bar:
+                continue
+            if (now - bar["start"]) < self._bar_interval:
+                continue
+            finalized = {key: float(bar[key]) for key in ("open", "high", "low", "close", "volume")}
+            history = self._ohlcv_history.setdefault(symbol, deque(maxlen=self._history))
+            history.append(finalized)
+            bar["start"] = now
+            bar["open"] = bar["close"]
+            bar["high"] = bar["close"]
+            bar["low"] = bar["close"]
+            bar["volume"] = 0.0

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -22,10 +22,36 @@ risk:
   max_position_duration_minutes: 180
 
 ml:
-  learning_rate: 0.045
-  regularization: 0.001
-  training_batch_size: 250
-  max_training_rows: 2000
+  feature_keys:
+    - momentum_1
+    - momentum_3
+    - momentum_5
+    - momentum_10
+    - rolling_volatility
+    - atr
+    - volume_delta
+    - volume_ratio
+    - volume_ratio_3
+    - volume_ratio_10
+    - body_pct
+    - upper_wick_pct
+    - lower_wick_pct
+    - wick_close_ratio
+    - range_pct
+    - ema_fast
+    - ema_slow
+    - macd
+    - macd_hist
+    - rsi
+    - zscore
+    - close_to_high
+    - close_to_low
+  learning_rate: 0.03
+  regularization: 0.0005
+  threshold: 0.7
+  ensemble_enabled: true
+  ensemble_trees: 15
+  random_state: 7
 
 workers:
   refresh_interval_seconds: 15

--- a/ai_trader/services/ml.py
+++ b/ai_trader/services/ml.py
@@ -1,0 +1,434 @@
+"""Online machine learning service for streaming trade intelligence."""
+
+from __future__ import annotations
+
+import json
+import pickle
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Mapping, Optional, Tuple
+
+from river import compose, ensemble, linear_model, optim, preprocessing
+
+from .logging import get_logger
+
+
+FeatureMapping = Mapping[str, float]
+
+
+@dataclass(slots=True)
+class _ModelBundle:
+    """Container holding the live online models for a trading symbol."""
+
+    pipeline: compose.Pipeline
+    forest: Optional[ensemble.AdaptiveRandomForestClassifier]
+
+    def learn(self, features: FeatureMapping, label: int) -> None:
+        """Update the online models with the observed label."""
+
+        self.pipeline.learn_one(features, label)
+        if self.forest is not None:
+            self.forest.learn_one(features, label)
+
+    def predict_proba(self, features: FeatureMapping) -> float:
+        """Return a blended probability using the configured ensemble."""
+
+        probability = self.pipeline.predict_proba_one(features).get(True, 0.0)
+        if self.forest is not None:
+            forest_probability = self.forest.predict_proba_one(features).get(True, 0.0)
+            probability = (probability + forest_probability) / 2
+        return float(max(0.0, min(1.0, probability)))
+
+    def feature_importances(self) -> Dict[str, float]:
+        """Expose the logistic regression coefficients for explainability."""
+
+        weights: Dict[str, float] = {}
+        try:
+            model: linear_model.LogisticRegression = self.pipeline[-1]
+        except (IndexError, TypeError, AttributeError):  # pragma: no cover - defensive fallback
+            return weights
+        for feature, weight in model.weights.items():
+            weights[str(feature)] = float(weight)
+        return weights
+
+
+class MLService:
+    """Stateful online learning engine shared across workers."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        feature_keys: Iterable[str],
+        learning_rate: float = 0.03,
+        regularization: float = 0.0005,
+        threshold: float = 0.7,
+        ensemble: bool = True,
+        forest_size: int = 15,
+        random_state: int = 7,
+    ) -> None:
+        self._db_path = db_path
+        self._feature_keys = list(feature_keys)
+        self._learning_rate = learning_rate
+        self._regularization = regularization
+        self._threshold = threshold
+        self._use_ensemble = ensemble
+        self._forest_size = forest_size
+        self._random_state = random_state
+        self._models: Dict[str, _ModelBundle] = {}
+        self._latest_features: Dict[str, Dict[str, float]] = {}
+        self._latest_confidence: Dict[Tuple[str, str], float] = {}
+        self._logger = get_logger(__name__)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ml_models_state (
+                    symbol TEXT PRIMARY KEY,
+                    logistic BLOB,
+                    forest BLOB,
+                    updated_at TEXT NOT NULL,
+                    metadata_json TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ml_predictions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    worker TEXT,
+                    confidence REAL NOT NULL,
+                    decision INTEGER NOT NULL,
+                    threshold REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ml_metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    precision REAL,
+                    recall REAL,
+                    win_rate REAL,
+                    support INTEGER
+                )
+                """
+            )
+            conn.commit()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Model lifecycle management
+    # ------------------------------------------------------------------
+    def _build_pipeline(self) -> compose.Pipeline:
+        optimizer = optim.SGD(learning_rate=self._learning_rate)
+        logistic = linear_model.LogisticRegression(optimizer=optimizer, l2=self._regularization)
+        return compose.Pipeline(preprocessing.StandardScaler(), logistic)
+
+    def _build_forest(self) -> ensemble.AdaptiveRandomForestClassifier:
+        return ensemble.AdaptiveRandomForestClassifier(
+            n_models=self._forest_size,
+            max_features="sqrt",
+            seed=self._random_state,
+        )
+
+    def _load_model(self, symbol: str) -> _ModelBundle:
+        if symbol in self._models:
+            return self._models[symbol]
+
+        pipeline = self._build_pipeline()
+        forest = self._build_forest() if self._use_ensemble else None
+
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT logistic, forest FROM ml_models_state WHERE symbol = ?",
+                (symbol,),
+            ).fetchone()
+        if row and row["logistic"]:
+            try:
+                pipeline = pickle.loads(row["logistic"])
+            except Exception as exc:  # noqa: BLE001 - fallback to fresh model
+                self._logger.warning("Failed to load logistic model for %s: %s", symbol, exc)
+                pipeline = self._build_pipeline()
+        if row and row["forest"] and self._use_ensemble:
+            try:
+                forest = pickle.loads(row["forest"])
+            except Exception as exc:  # noqa: BLE001 - fallback to fresh model
+                self._logger.warning("Failed to load forest model for %s: %s", symbol, exc)
+                forest = self._build_forest()
+
+        bundle = _ModelBundle(pipeline=pipeline, forest=forest)
+        self._models[symbol] = bundle
+        return bundle
+
+    def _persist_model(self, symbol: str, bundle: _ModelBundle) -> None:
+        logistic_blob = pickle.dumps(bundle.pipeline)
+        forest_blob = pickle.dumps(bundle.forest) if bundle.forest is not None else None
+        metadata = json.dumps({"ensemble": self._use_ensemble})
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ml_models_state(symbol, logistic, forest, updated_at, metadata_json)
+                VALUES(?, ?, ?, ?, ?)
+                ON CONFLICT(symbol) DO UPDATE SET
+                    logistic = excluded.logistic,
+                    forest = excluded.forest,
+                    updated_at = excluded.updated_at,
+                    metadata_json = excluded.metadata_json
+                """,
+                (
+                    symbol,
+                    logistic_blob,
+                    forest_blob,
+                    datetime.utcnow().isoformat(),
+                    metadata,
+                ),
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def feature_keys(self) -> Iterable[str]:
+        return tuple(self._feature_keys)
+
+    @property
+    def default_threshold(self) -> float:
+        return self._threshold
+
+    def update(
+        self,
+        symbol: str,
+        features: Mapping[str, float],
+        label: Optional[float] = None,
+        *,
+        persist: bool = True,
+        timestamp: Optional[datetime] = None,
+    ) -> float:
+        """Update the models with a new feature vector and optional label.
+
+        Returns the current confidence so researcher workers can monitor drift.
+        """
+
+        cleaned = self._sanitize_features(features)
+        self._latest_features[symbol] = cleaned
+        model = self._load_model(symbol)
+
+        probability = model.predict_proba(cleaned)
+        if label is not None:
+            model.learn(cleaned, int(label))
+            probability = model.predict_proba(cleaned)
+            if persist:
+                self._persist_model(symbol, model)
+
+        self._record_prediction(
+            symbol=symbol,
+            worker="researcher",
+            probability=probability,
+            decision=int(probability >= self._threshold),
+            threshold=self._threshold,
+            timestamp=timestamp or datetime.utcnow(),
+        )
+        return probability
+
+    def predict(
+        self,
+        symbol: str,
+        features: Optional[Mapping[str, float]] = None,
+        *,
+        worker: Optional[str] = None,
+        threshold: Optional[float] = None,
+    ) -> Tuple[bool, float]:
+        """Return (decision, confidence) for the supplied feature vector."""
+
+        model = self._load_model(symbol)
+        feature_payload: Mapping[str, float] | None = features or self._latest_features.get(symbol)
+        if feature_payload is None:
+            return False, 0.0
+
+        cleaned = self._sanitize_features(feature_payload)
+        probability = model.predict_proba(cleaned)
+        gate = threshold if threshold is not None else self._threshold
+        decision = probability >= gate
+        worker_name = worker or "worker"
+        self._latest_confidence[(worker_name, symbol)] = probability
+        self._record_prediction(
+            symbol=symbol,
+            worker=worker_name,
+            probability=probability,
+            decision=int(decision),
+            threshold=gate,
+            timestamp=datetime.utcnow(),
+        )
+        return decision, probability
+
+    def latest_confidence(self, symbol: str, worker: Optional[str] = None) -> float:
+        """Expose the last scored confidence for dashboards."""
+
+        key = (worker or "worker", symbol)
+        return self._latest_confidence.get(key, 0.0)
+
+    def latest_features(self, symbol: str) -> Optional[Dict[str, float]]:
+        """Return the last seen feature vector for a symbol."""
+
+        return self._latest_features.get(symbol)
+
+    def feature_importance(self, symbol: str, top_n: int = 10) -> Dict[str, float]:
+        """Return the top-N absolute weighted features for the symbol."""
+
+        model = self._load_model(symbol)
+        weights = model.feature_importances()
+        sorted_items = sorted(weights.items(), key=lambda item: abs(item[1]), reverse=True)
+        return dict(sorted_items[:top_n])
+
+    def confidence_history(self, symbol: str, limit: int = 200) -> list[tuple[datetime, float, str]]:
+        """Fetch recent confidence readings for charting."""
+
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT timestamp, confidence, worker
+                FROM ml_predictions
+                WHERE symbol = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """,
+                (symbol, limit),
+            ).fetchall()
+        history: list[tuple[datetime, float, str]] = []
+        for row in rows:
+            history.append((datetime.fromisoformat(row["timestamp"]), float(row["confidence"]), row["worker"]))
+        return list(reversed(history))
+
+    def run_backtest(self, symbol: str, limit: int = 1500, *, threshold: Optional[float] = None) -> Dict[str, float]:
+        """Replay stored features and return classification metrics."""
+
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT timestamp, features_json, label
+                FROM market_features
+                WHERE symbol = ? AND label IS NOT NULL
+                ORDER BY timestamp ASC
+                LIMIT ?
+                """,
+                (symbol, limit),
+            ).fetchall()
+
+        if not rows:
+            return {"precision": 0.0, "recall": 0.0, "win_rate": 0.0, "support": 0}
+
+        test_model = _ModelBundle(pipeline=self._build_pipeline(), forest=self._build_forest() if self._use_ensemble else None)
+        gate = threshold if threshold is not None else self._threshold
+
+        true_positive = false_positive = true_negative = false_negative = 0
+
+        for row in rows:
+            payload = json.loads(row["features_json"])
+            features = self._sanitize_features(payload)
+            label = int(row["label"])
+            proba = test_model.predict_proba(features)
+            prediction = int(proba >= gate)
+            if prediction == 1 and label == 1:
+                true_positive += 1
+            elif prediction == 1 and label == 0:
+                false_positive += 1
+            elif prediction == 0 and label == 0:
+                true_negative += 1
+            elif prediction == 0 and label == 1:
+                false_negative += 1
+            test_model.learn(features, label)
+
+        precision = true_positive / (true_positive + false_positive) if (true_positive + false_positive) else 0.0
+        recall = true_positive / (true_positive + false_negative) if (true_positive + false_negative) else 0.0
+        win_rate = true_positive / (true_positive + false_positive + false_negative + true_negative) if (true_positive + false_positive + false_negative + true_negative) else 0.0
+
+        metrics_payload = {
+            "precision": precision,
+            "recall": recall,
+            "win_rate": win_rate,
+            "support": true_positive + false_positive + false_negative + true_negative,
+        }
+
+        self._record_metrics(symbol, "backtest", metrics_payload)
+        return metrics_payload
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _sanitize_features(self, features: Mapping[str, float]) -> Dict[str, float]:
+        sanitized: Dict[str, float] = {}
+        for key in self._feature_keys:
+            value = float(features.get(key, 0.0))
+            if value != value:  # NaN check without importing math
+                value = 0.0
+            sanitized[key] = value
+        return sanitized
+
+    def _record_prediction(
+        self,
+        *,
+        symbol: str,
+        worker: str,
+        probability: float,
+        decision: int,
+        threshold: float,
+        timestamp: datetime,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ml_predictions(timestamp, symbol, worker, confidence, decision, threshold)
+                VALUES(?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    timestamp.isoformat(),
+                    symbol,
+                    worker,
+                    float(probability),
+                    int(decision),
+                    float(threshold),
+                ),
+            )
+            conn.commit()
+
+    def _record_metrics(self, symbol: str, mode: str, metrics: Mapping[str, float]) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ml_metrics(timestamp, symbol, mode, precision, recall, win_rate, support)
+                VALUES(?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    datetime.utcnow().isoformat(),
+                    symbol,
+                    mode,
+                    float(metrics.get("precision", 0.0)),
+                    float(metrics.get("recall", 0.0)),
+                    float(metrics.get("win_rate", 0.0)),
+                    int(metrics.get("support", 0)),
+                ),
+            )
+            conn.commit()
+

--- a/ai_trader/services/types.py
+++ b/ai_trader/services/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 TradeAction = Literal["OPEN", "CLOSE"]
 TradeSide = Literal["buy", "sell"]
@@ -54,4 +54,5 @@ class MarketSnapshot:
 
     prices: dict[str, float]
     history: dict[str, list[float]]
+    candles: Dict[str, List[dict[str, float]]] = field(default_factory=dict)
     timestamp: datetime = field(default_factory=datetime.utcnow)

--- a/ai_trader/workers/mean_reversion.py
+++ b/ai_trader/workers/mean_reversion.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import statistics
 from typing import Dict, Optional
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..services.ml import MLService
+
 from .base import BaseWorker
 from ..services.types import MarketSnapshot, OpenPosition, TradeIntent
 
@@ -15,8 +20,14 @@ class MeanReversionWorker(BaseWorker):
     name = "Mean Reverter"
     emoji = "🔄"
 
-    def __init__(self, symbols, window: int = 20, threshold: float = 0.01) -> None:
-        super().__init__(symbols=symbols, lookback=window * 3)
+    def __init__(
+        self,
+        symbols,
+        window: int = 20,
+        threshold: float = 0.01,
+        ml_service: "MLService" | None = None,
+    ) -> None:
+        super().__init__(symbols=symbols, lookback=window * 3, ml_service=ml_service)
         self.window = window
         self.threshold = threshold
 
@@ -53,6 +64,10 @@ class MeanReversionWorker(BaseWorker):
             return None
 
         if signal in {"buy", "sell"} and existing_position is None:
+            allowed, confidence = self.ml_confirmation(symbol)
+            if not allowed:
+                self.update_signal_state(symbol, "ml-block", {"ml_confidence": confidence})
+                return None
             return TradeIntent(
                 worker=self.name,
                 action="OPEN",
@@ -60,6 +75,7 @@ class MeanReversionWorker(BaseWorker):
                 side=signal,
                 cash_spent=equity_per_trade,
                 entry_price=price,
+                confidence=confidence,
             )
 
         if signal == "flat" and existing_position is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ plotly==5.20.0
 streamlit==1.32.0
 colorama==0.4.6
 numpy==1.26.4
+river==0.21.1


### PR DESCRIPTION
## Summary
- implement a streaming ML service that blends online logistic regression with an adaptive random forest ensemble and persists model state, confidence history, and backtest metrics
- expand the researcher and trading workers to engineer richer OHLCV features, feed the ML service, and gate trade execution based on confidence while the websocket now rolls live candles
- enhance the Streamlit dashboard with ML confidence overlays, feature importance charts, and on-demand backtests plus configuration controls for ML gating

## Testing
- python -m compileall ai_trader

------
https://chatgpt.com/codex/tasks/task_e_68d0e1f11410832faecc96b8f3bddd3f