### PR TITLE
Fix: load researcher worker configuration

### DIFF
--- a/ai_trader/services/worker_loader.py
+++ b/ai_trader/services/worker_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
 
 from ..services.logging import get_logger
 
@@ -20,8 +20,7 @@ class WorkerLoader:
     def load(self, shared_services: Dict[str, Any]) -> Tuple[List[object], List[object]]:
         workers: List[object] = []
         researchers: List[object] = []
-        definitions = self._worker_config.get("definitions", {})
-        for worker_name, definition in definitions.items():
+        for worker_name, definition, force_researcher in self._iter_definitions():
             if not definition.get("enabled", True):
                 self._logger.info("Worker %s disabled via configuration", worker_name)
                 continue
@@ -29,25 +28,75 @@ class WorkerLoader:
             if not dotted_path:
                 self._logger.warning("Worker %s missing module path", worker_name)
                 continue
-            module_name, class_name = dotted_path.rsplit(".", 1)
-            module = importlib.import_module(module_name)
-            worker_cls = getattr(module, class_name)
-            kwargs: Dict[str, Any] = {}
-            symbols = definition.get("symbols", self._symbols)
-            params = definition.get("parameters", {})
-            risk_cfg = definition.get("risk", {})
-            signature = inspect.signature(worker_cls)
-            for param_name in signature.parameters:
-                if param_name == "symbols":
-                    kwargs[param_name] = symbols
-                elif param_name == "config":
-                    kwargs[param_name] = params
-                elif param_name == "risk_config":
-                    kwargs[param_name] = risk_cfg
-                elif param_name in shared_services:
-                    kwargs[param_name] = shared_services[param_name]
-            worker = worker_cls(**kwargs)
-            target = researchers if getattr(worker, "is_researcher", False) else workers
+            try:
+                module_name, class_name = dotted_path.rsplit(".", 1)
+                module = importlib.import_module(module_name)
+                worker_cls = getattr(module, class_name)
+                kwargs: Dict[str, Any] = {}
+                symbols = definition.get("symbols", self._symbols)
+                params = definition.get("parameters", {})
+                risk_cfg = definition.get("risk", {})
+                signature = inspect.signature(worker_cls)
+                for param_name in signature.parameters:
+                    if param_name == "symbols":
+                        kwargs[param_name] = symbols
+                    elif param_name == "config":
+                        kwargs[param_name] = params
+                    elif param_name == "risk_config":
+                        kwargs[param_name] = risk_cfg
+                    elif param_name in shared_services:
+                        kwargs[param_name] = shared_services[param_name]
+                worker = worker_cls(**kwargs)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self._logger.exception("Failed to load worker %s (%s): %s", worker_name, dotted_path, exc)
+                continue
+            target = researchers if force_researcher or getattr(worker, "is_researcher", False) else workers
             target.append(worker)
             self._logger.info("Worker %s loaded (%s)", worker.name, dotted_path)
         return workers, researchers
+
+    def _iter_definitions(self) -> Iterator[Tuple[str, Dict[str, Any], bool]]:
+        """Yield worker definitions along with research hints.
+
+        Returns tuples of ``(worker_key, definition, force_researcher)`` so the
+        loader can route researcher-style workers correctly even if the class
+        lacks the ``is_researcher`` attribute. The existing ``definitions``
+        mapping is processed first to maintain backwards compatibility, and the
+        legacy top-level ``researcher`` block is normalised into the same
+        structure.
+        """
+
+        definitions = self._worker_config.get("definitions", {})
+        if isinstance(definitions, dict):
+            for worker_name, definition in definitions.items():
+                yield worker_name, definition, False
+
+        researcher_cfg = self._worker_config.get("researcher")
+        if not researcher_cfg:
+            return
+
+        for worker_name, definition in self._coerce_researchers(researcher_cfg):
+            yield worker_name, definition, True
+
+    @staticmethod
+    def _coerce_researchers(
+        researcher_cfg: Any,
+    ) -> Iterable[Tuple[str, Dict[str, Any]]]:
+        """Normalise researcher configuration into iterable key/config pairs."""
+
+        if isinstance(researcher_cfg, dict):
+            module = researcher_cfg.get("module")
+            # Single researcher configuration at the top level.
+            if module or researcher_cfg.get("parameters"):
+                yield researcher_cfg.get("name", "researcher"), researcher_cfg
+                return
+            for worker_name, definition in researcher_cfg.items():
+                if isinstance(definition, dict):
+                    yield worker_name, definition
+            return
+
+        if isinstance(researcher_cfg, list):
+            for index, definition in enumerate(researcher_cfg):
+                if isinstance(definition, dict):
+                    yield definition.get("name", f"researcher_{index}"), definition
+


### PR DESCRIPTION
## Summary
- teach the worker loader to normalize the legacy `researcher` config block so MarketResearchWorker instances start
- add defensive error handling while constructing workers to avoid aborting the entire loader when one worker fails

## Testing
- python -m compileall ai_trader

------
https://chatgpt.com/codex/tasks/task_e_68d0f1122f28832f8e500fdf7f72dcf2