### PR TITLE
Refactor: enforce researcher loading and startup validation

### DIFF
--- a/ai_trader/dashboard/app.py
+++ b/ai_trader/dashboard/app.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import sys, os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -16,9 +14,18 @@ from plotly.subplots import make_subplots
 import streamlit as st
 import yaml
 
-from ai_trader.services.ml import MLService
-
 BASE_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = BASE_DIR.parent
+
+try:
+    from ai_trader.services.ml import MLService
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct script execution
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+    from ai_trader.services.ml import MLService
+
+st.set_page_config(page_title="AI Trader Control Center", layout="wide", page_icon="🧠")
+
 DB_PATH = BASE_DIR / "data" / "trades.db"
 CONFIG_PATH = BASE_DIR / "config.yaml"
 MODULE_DISPLAY_NAMES = {
@@ -27,8 +34,6 @@ MODULE_DISPLAY_NAMES = {
     "ai_trader.workers.ml_short.MLShortWorker": "ML Short Alpha",
     "ai_trader.workers.researcher.MarketResearchWorker": "Research Sentinel",
 }
-
-st.set_page_config(page_title="AI Trader Control Center", layout="wide", page_icon="🧠")
 
 CUSTOM_CSS = """
 <style>

--- a/ai_trader/services/ml.py
+++ b/ai_trader/services/ml.py
@@ -217,6 +217,23 @@ class MLService:
     def default_threshold(self) -> float:
         return self._threshold
 
+    def has_feature_history(self, symbols: Optional[Iterable[str]] = None) -> bool:
+        """Return True when at least one engineered feature row exists."""
+
+        query = "SELECT 1 FROM market_features"
+        params: Tuple[str, ...] = ()
+        if symbols:
+            symbol_list = tuple(str(symbol) for symbol in symbols)
+            if not symbol_list:
+                return False
+            placeholders = ", ".join(["?"] * len(symbol_list))
+            query += f" WHERE symbol IN ({placeholders})"
+            params = symbol_list
+        query += " LIMIT 1"
+        with self._connect() as conn:
+            row = conn.execute(query, params).fetchone()
+        return row is not None
+
     def update(
         self,
         symbol: str,

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Helper script to bootstrap the local dev environment and launch the AI trader bot.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$venvPath = Join-Path -Path (Get-Location) -ChildPath '.venv'
+if (-not (Test-Path -Path $venvPath)) {
+    Write-Host 'Creating virtual environment (.venv)...'
+    python -m venv $venvPath
+}
+
+$activateScript = Join-Path -Path $venvPath -ChildPath 'Scripts\Activate.ps1'
+if (-not (Test-Path -Path $activateScript)) {
+    throw "Virtual environment activation script not found at $activateScript"
+}
+
+. $activateScript
+
+Write-Host 'Installing dependencies from requirements.txt...'
+pip install --upgrade pip
+pip install -r requirements.txt
+
+Write-Host 'Starting AI Trader bot...'
+python -m ai_trader.main


### PR DESCRIPTION
## Summary
- normalize researcher configuration in the worker loader so MarketResearchWorker is always instantiated and warn when missing
- ensure the Streamlit dashboard uses absolute imports with a guarded sys.path fallback and configures the page exactly once at startup
- add startup validation for missing researchers, schema gaps, and ML feature history while providing a Windows PowerShell bootstrap script

## Testing
- python -m compileall ai_trader

------
https://chatgpt.com/codex/tasks/task_e_68d107ee1828832f9718ad96482391e9