### PR TITLE
Fix: enforce ML pipeline warmup and researcher integration

### DIFF
--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -48,9 +48,9 @@ ml:
     - close_to_low
   lr: 0.03
   regularization: 0.0005
-  threshold: 0.7
-  ensemble: true
-  forest_size: 15
+  threshold: 0.2
+  ensemble_enabled: true
+  ensemble_trees: 15
   random_state: 7
 
 workers:
@@ -66,7 +66,8 @@ workers:
         fast_window: 12
         slow_window: 48
         momentum_threshold: 0.004
-        warmup_candles: 10
+        warmup_candles: 3
+        ml_threshold: 0.35
       risk:
         leverage: 2.0
         position_size_pct: 110.0
@@ -81,7 +82,8 @@ workers:
       parameters:
         band_window: 20
         band_std_dev: 2.4
-        warmup_candles: 10
+        warmup_candles: 3
+        ml_threshold: 0.32
         reversion_threshold: 0.0035
       risk:
         leverage: 1.6
@@ -97,8 +99,9 @@ workers:
         - "ETH/USD"
       parameters:
         feature_lookback: 30
-        probability_threshold: 0.62
-        warmup_candles: 10
+        probability_threshold: 0.5
+        warmup_candles: 3
+        ml_threshold: 0.35
       risk:
         leverage: 1.8
         position_size_pct: 100.0
@@ -113,7 +116,7 @@ researcher:
     - "BTC/USD"
     - "ETH/USD"
   parameters:
-    warmup_candles: 10
+    warmup_candles: 3
     feature_windows:
       - 5
       - 14

--- a/ai_trader/services/worker_loader.py
+++ b/ai_trader/services/worker_loader.py
@@ -22,6 +22,8 @@ class WorkerLoader:
         self._symbols = list(symbols)
         self._logger = get_logger(__name__)
         self._forced_researchers: Set[str] = self._normalize_researchers(researcher_config)
+        self._auto_researcher_key: str | None = None
+        self._ensure_researcher_placeholder()
         if not self._forced_researchers:
             self._logger.warning(
                 "No market researcher configured; ML feature engineering will remain idle."
@@ -30,6 +32,7 @@ class WorkerLoader:
     def load(self, shared_services: Dict[str, Any]) -> Tuple[List[object], List[object]]:
         workers: List[object] = []
         researchers: List[object] = []
+        ml_enabled_workers: List[object] = []
         for worker_name, definition, force_researcher in self._iter_definitions():
             if not definition.get("enabled", True):
                 self._logger.info("Worker %s disabled via configuration", worker_name)
@@ -60,13 +63,24 @@ class WorkerLoader:
             except Exception as exc:  # pragma: no cover - defensive logging
                 self._logger.exception("Failed to load worker %s (%s): %s", worker_name, dotted_path, exc)
                 continue
-            target = researchers if force_researcher or getattr(worker, "is_researcher", False) else workers
+            is_researcher = force_researcher or getattr(worker, "is_researcher", False)
+            target = researchers if is_researcher else workers
             target.append(worker)
             self._logger.info("Worker %s loaded (%s)", worker.name, dotted_path)
+            if not is_researcher and getattr(worker, "_ml_service", None) is not None:
+                ml_enabled_workers.append(worker)
         if not researchers:
             self._logger.warning(
                 "No MarketResearchWorker instances were loaded; ML feature engineering will remain offline."
             )
+        if ml_enabled_workers and not researchers:
+            injected = self._inject_default_researcher(shared_services)
+            if injected is not None:
+                researchers.append(injected)
+                self._logger.warning(
+                    "Injected fallback MarketResearchWorker because %d ML worker(s) require research data.",
+                    len(ml_enabled_workers),
+                )
         return workers, researchers
 
     def _iter_definitions(self) -> Iterator[Tuple[str, Dict[str, Any], bool]]:
@@ -87,6 +101,40 @@ class WorkerLoader:
         for worker_name, definition in definitions.items():
             force_researcher = worker_name in self._forced_researchers
             yield worker_name, definition, force_researcher
+
+    def _ensure_researcher_placeholder(self) -> None:
+        """Inject a default researcher definition when ML workers are configured."""
+
+        definitions = self._worker_config.setdefault("definitions", {})
+        if not isinstance(definitions, dict):
+            return
+
+        has_researcher = any(self._looks_like_researcher(defn) for defn in definitions.values())
+        ml_workers_present = any(
+            self._definition_requires_research(defn) for defn in definitions.values()
+        )
+        if ml_workers_present and not has_researcher:
+            self._auto_researcher_key = "auto_researcher"
+            definitions.setdefault(
+                self._auto_researcher_key,
+                {
+                    "module": "ai_trader.workers.researcher.MarketResearchWorker",
+                    "enabled": True,
+                    "parameters": {"warmup_candles": 3, "log_every_n_snapshots": 1},
+                },
+            )
+            self._forced_researchers.add(self._auto_researcher_key)
+
+    def _definition_requires_research(self, definition: Dict[str, Any]) -> bool:
+        module = str(definition.get("module", ""))
+        if not module:
+            return False
+        if bool(definition.get("ml_required")):
+            return True
+        lowered = module.lower()
+        if "ml_" in lowered or lowered.endswith("mlworker") or "mlshort" in lowered:
+            return True
+        return False
 
     def _normalize_researchers(self, external_config: Any | None) -> Set[str]:
         """Normalise legacy researcher config blocks into worker definitions."""
@@ -157,4 +205,41 @@ class WorkerLoader:
         if isinstance(module, str) and module.endswith("MarketResearchWorker"):
             return True
         return bool(definition.get("is_researcher"))
+
+    def _inject_default_researcher(self, shared_services: Dict[str, Any]) -> object | None:
+        """Instantiate an auto-injected MarketResearchWorker when needed."""
+
+        if self._auto_researcher_key is None:
+            return None
+        definitions = self._worker_config.get("definitions", {})
+        definition = definitions.get(self._auto_researcher_key)
+        if not isinstance(definition, dict):
+            return None
+
+        try:
+            module_name, class_name = str(definition["module"]).rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            worker_cls = getattr(module, class_name)
+            params = definition.get("parameters", {})
+            signature = inspect.signature(worker_cls)
+            kwargs: Dict[str, Any] = {}
+            for param_name in signature.parameters:
+                if param_name == "symbols":
+                    kwargs[param_name] = self._symbols
+                elif param_name == "config":
+                    kwargs[param_name] = params
+                elif param_name in shared_services:
+                    kwargs[param_name] = shared_services[param_name]
+            worker = worker_cls(**kwargs)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.exception(
+                "Failed to inject default MarketResearchWorker: %s", exc
+            )
+            return None
+        self._logger.info(
+            "Worker %s loaded (%s) [auto-injected]",
+            worker.name,
+            definition.get("module"),
+        )
+        return worker
 


### PR DESCRIPTION
## Summary
- normalize researcher configuration, auto-inject a MarketResearchWorker when ML-gated workers are enabled, and align ML thresholds/warmups in config
- harden the online ML service with defensive logging, non-empty feature importance handling, and warn when predictions lack features
- add richer researcher logging plus an ML diagnostics dashboard panel and startup checks so the pipeline only trades once data is flowing

## Testing
- python -m ai_trader.main *(fails: Kraken public API is unreachable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1df779ca0832f8106920016cce7ba