### PR TITLE
Fix: handle Kraken precision metadata for fractional steps

### DIFF
--- a/tests/test_kraken_client.py
+++ b/tests/test_kraken_client.py
@@ -43,3 +43,18 @@ def test_normalise_balance_asset_strips_suffix(monkeypatch: pytest.MonkeyPatch) 
     assert client._normalise_balance_asset("eth.s") == "ETH"
     assert client._normalise_balance_asset(" usd ") == "USD"
     assert client._normalise_balance_asset("") == ""
+
+
+def test_apply_precision_handles_fractional_steps() -> None:
+    client = DummyKrakenClient()
+
+    # Kraken can report the precision as a fractional step (e.g. 0.001). The
+    # helper should trim to the nearest multiple of that step without raising.
+    assert client._apply_precision(1.234567, 0.001) == pytest.approx(1.234)
+
+
+def test_apply_precision_accepts_decimal_digits() -> None:
+    client = DummyKrakenClient()
+
+    # Precision values represented as strings should be treated as digit counts.
+    assert client._apply_precision(0.123456789, "5") == pytest.approx(0.12345)


### PR DESCRIPTION
## Summary
- guard Kraken order sizing against ccxt markets that report precision as a fractional step
- ensure the precision helper can handle both decimal-step and digit-count formats
- expand broker client tests to cover the new precision handling scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38bcfdf68832f9e7346b93f33336e