### PR TITLE
Feat: enforce long-only risk controls

### DIFF
--- a/ai_trader/broker/kraken_client.py
+++ b/ai_trader/broker/kraken_client.py
@@ -60,6 +60,10 @@ class KrakenClient:
     def is_paper_trading(self) -> bool:
         return self._paper_trading
 
+    @property
+    def base_currency(self) -> str:
+        return self._base_currency
+
     async def load_markets(self) -> None:
         markets = await self._with_retries(
             self._exchange.load_markets, description="load_markets"

--- a/ai_trader/config.live.yaml
+++ b/ai_trader/config.live.yaml
@@ -4,15 +4,16 @@ trading:
   paper_trading: false
   equity_allocation_percent: 1.0
   max_open_positions: 2
-  allow_shorting: true
-  min_cash_per_trade: 15.0
+  allow_shorting: false
+  min_cash_per_trade: 10.0
+  trade_confidence_min: 0.6
 
 risk:
   max_drawdown_percent: 8.0
   daily_loss_limit_percent: 1.5
 
 ml:
-  threshold: 0.4
+  threshold: 0.5
   warmup_samples: 50
   ensemble: true
 

--- a/ai_trader/config.paper-live.example.yaml
+++ b/ai_trader/config.paper-live.example.yaml
@@ -18,8 +18,9 @@ trading:
   max_open_positions: 2
   paper_trading: true
   paper_starting_equity: 20000.0
-  allow_shorting: true
-  min_cash_per_trade: 15.0
+  allow_shorting: false
+  min_cash_per_trade: 10.0
+  trade_confidence_min: 0.5
   mode: "paper"  # Toggle to "live" only after credentials + production risk checks.
 
 risk:
@@ -30,7 +31,7 @@ risk:
 ml:
   lr: 0.03
   regularization: 0.0005
-  threshold: 0.25
+  threshold: 0.5
   ensemble: true
   forest_size: 10
   random_state: 7

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -14,8 +14,9 @@ trading:
   max_open_positions: 3
   paper_trading: true
   paper_starting_equity: 25000.0
-  allow_shorting: true
-  min_cash_per_trade: 15.0
+  allow_shorting: false
+  min_cash_per_trade: 10.0
+  trade_confidence_min: 0.5
   mode: "paper"  # Toggle to "live" only after loading env credentials and restarting the bot.
 
 risk:
@@ -50,7 +51,7 @@ ml:
     - close_to_low
   lr: 0.03
   regularization: 0.0005
-  threshold: 0.25  # Raise towards 0.55–0.65 for stricter production gating.
+  threshold: 0.5  # Raise towards 0.55–0.65 for stricter production gating.
   ensemble: true
   forest_size: 10
   random_state: 7

--- a/ai_trader/main.py
+++ b/ai_trader/main.py
@@ -433,7 +433,8 @@ async def start_bot() -> None:
         max_open_positions=int(trading_cfg.get("max_open_positions", 3)),
         refresh_interval=float(worker_cfg.get("refresh_interval_seconds", 30)),
         paper_trading=broker.is_paper_trading,
-        min_cash_per_trade=float(trading_cfg.get("min_cash_per_trade", 15.0)),
+        min_cash_per_trade=float(trading_cfg.get("min_cash_per_trade", 10.0)),
+        trade_confidence_min=float(trading_cfg.get("trade_confidence_min", 0.5)),
     )
 
     try:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -20,7 +20,7 @@ def test_normalize_config_maps_deprecated_keys(caplog) -> None:
     assert ml_cfg["lr"] == 0.1
     assert ml_cfg["forest_size"] == 25
     assert ml_cfg["ensemble"] is True
-    assert ml_cfg["threshold"] == 0.25
+    assert ml_cfg["threshold"] == 0.5
     assert "learning_rate" in caplog.text
     assert "ensemble_trees" in caplog.text
 
@@ -35,3 +35,4 @@ def test_normalize_config_sanitises_symbols() -> None:
     normalised = normalize_config(config)
 
     assert normalised["trading"]["symbols"] == ["BTC/USD", "SOL/USD", "ETH/USD"]
+    assert normalised["trading"]["trade_confidence_min"] == 0.5


### PR DESCRIPTION
## Summary
- enforce long-only trading by blocking short opens, gating SELL exits to existing longs, and logging ML short blocks
- verify Kraken balances before sizing orders, clamp trades to $10–$20 cash floor, and expose configurable ML confidence filter
- update configs and tests to reflect higher ML thresholds, new risk guardrails, and insufficient-fund handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3990d7b24832f96f3661c46e3b4f2