### PR TITLE
Enforce long-only policy and tighten trade sizing

### DIFF
--- a/ai_trader/broker/kraken_client.py
+++ b/ai_trader/broker/kraken_client.py
@@ -174,15 +174,15 @@ class KrakenClient:
             return float(price), float(amount)
 
         should_reduce_only = False
-        if reduce_only is None:
-            should_reduce_only = side == "sell" and not self._allow_shorting
-        else:
-            # Always enforce reduce_only when shorting is disabled even if explicitly
-            # overridden. This prevents accidental naked short exposure when the
-            # deployment configuration disallows it.
-            should_reduce_only = reduce_only or (
-                side == "sell" and not self._allow_shorting
-            )
+        if side == "sell":
+            should_reduce_only = True
+            if reduce_only is False:
+                self._logger.debug(
+                    "Ignoring explicit reduce_only=False for %s sell order; enforcing long-only exit.",
+                    symbol,
+                )
+        elif reduce_only is not None:
+            should_reduce_only = bool(reduce_only)
 
         order_params: Dict[str, Any] = {}
         if should_reduce_only:

--- a/ai_trader/config.live.yaml
+++ b/ai_trader/config.live.yaml
@@ -6,6 +6,7 @@ trading:
   max_open_positions: 2
   allow_shorting: false
   min_cash_per_trade: 10.0
+  max_cash_per_trade: 20.0
   trade_confidence_min: 0.6
 
 risk:

--- a/ai_trader/config.paper-live.example.yaml
+++ b/ai_trader/config.paper-live.example.yaml
@@ -20,6 +20,7 @@ trading:
   paper_starting_equity: 20000.0
   allow_shorting: false
   min_cash_per_trade: 10.0
+  max_cash_per_trade: 20.0
   trade_confidence_min: 0.5
   mode: "paper"  # Toggle to "live" only after credentials + production risk checks.
 

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -16,6 +16,7 @@ trading:
   paper_starting_equity: 25000.0
   allow_shorting: false
   min_cash_per_trade: 10.0
+  max_cash_per_trade: 20.0
   trade_confidence_min: 0.5
   mode: "paper"  # Toggle to "live" only after loading env credentials and restarting the bot.
 

--- a/ai_trader/main.py
+++ b/ai_trader/main.py
@@ -434,6 +434,7 @@ async def start_bot() -> None:
         refresh_interval=float(worker_cfg.get("refresh_interval_seconds", 30)),
         paper_trading=broker.is_paper_trading,
         min_cash_per_trade=float(trading_cfg.get("min_cash_per_trade", 10.0)),
+        max_cash_per_trade=float(trading_cfg.get("max_cash_per_trade", 20.0)),
         trade_confidence_min=float(trading_cfg.get("trade_confidence_min", 0.5)),
     )
 

--- a/ai_trader/services/configuration.py
+++ b/ai_trader/services/configuration.py
@@ -120,6 +120,7 @@ def normalize_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     trading_cfg.setdefault("paper_starting_equity", 25000.0)
     trading_cfg.setdefault("max_open_positions", 3)
     trading_cfg.setdefault("min_cash_per_trade", 10.0)
+    trading_cfg.setdefault("max_cash_per_trade", 20.0)
     trading_cfg.setdefault("trade_confidence_min", 0.5)
     raw_symbols = trading_cfg.get("symbols", [])
     normalised_symbols: list[str] = []
@@ -158,11 +159,15 @@ def normalize_config(config: Mapping[str, Any]) -> Dict[str, Any]:
         trading_cfg.get("max_open_positions", 3)
     )
     min_cash = float(trading_cfg.get("min_cash_per_trade", 10.0))
+    max_cash = float(trading_cfg.get("max_cash_per_trade", 20.0))
     # Enforce the $10–$20 sizing policy so strategies cannot accidentally
     # request orders that fall outside the broker-compliant range. Values
     # outside the bounds are clamped rather than rejected to keep the bot
     # resilient to misconfiguration during live deployments.
-    trading_cfg["min_cash_per_trade"] = max(10.0, min(20.0, min_cash))
+    min_cash = max(10.0, min(20.0, min_cash))
+    max_cash = max(min_cash, min(20.0, max_cash))
+    trading_cfg["min_cash_per_trade"] = min_cash
+    trading_cfg["max_cash_per_trade"] = max_cash
     confidence_floor = float(trading_cfg.get("trade_confidence_min", 0.5))
     trading_cfg["trade_confidence_min"] = max(0.0, min(1.0, confidence_floor))
     normalised["trading"] = trading_cfg

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -36,3 +36,14 @@ def test_normalize_config_sanitises_symbols() -> None:
 
     assert normalised["trading"]["symbols"] == ["BTC/USD", "SOL/USD", "ETH/USD"]
     assert normalised["trading"]["trade_confidence_min"] == 0.5
+    assert normalised["trading"]["max_cash_per_trade"] == 20.0
+
+
+def test_normalize_config_clamps_trade_size_band() -> None:
+    config = {"trading": {"min_cash_per_trade": 2.5, "max_cash_per_trade": 50.0}}
+
+    normalised = normalize_config(config)
+    trading = normalised["trading"]
+
+    assert trading["min_cash_per_trade"] == 10.0
+    assert trading["max_cash_per_trade"] == 20.0


### PR DESCRIPTION
## Summary
- block ML-generated short entries, require reduce-only sells, and log risk skips in long-only mode
- clamp trade sizing to the configurable $10–$20 band with confidence and balance checks before order placement
- extend configuration defaults and pytest coverage for short blocking, low-confidence skips, insufficient funds, and sizing caps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42276ea9c832f8a3131d92329d5f2