### PR TITLE
Update 20pct monthly

### DIFF
--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -1,7 +1,6 @@
 kraken:
-  
-   api_key: ''
-     api_secret: ''
+  api_key: ''
+  api_secret: ''
   rest_rate_limit: 0.5
 trading:
   base_currency: USD

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -1,6 +1,7 @@
 kraken:
-  api_key: ''
-  api_secret: ''
+  
+       api_key: ''
+         api_secret: ''
   rest_rate_limit: 0.5
 trading:
   base_currency: USD
@@ -13,13 +14,13 @@ trading:
   paper_trading: false
   paper_starting_equity: 200.0
   allow_shorting: false
-  min_cash_per_trade: 5.0.0
-  max_cash_per_trade: 10.0.0
+min_cash_per_trade: 5.0
+ max_cash_per_trade: 10.0
   trade_confidence_min:   0.6
   mode: live
 risk:
-  max_drawdown_p:ercent 20.0
-  daily_loss_limit_p:ercent 5.0
+  max_drawdown_percent: 20.0
+    daily_loss_limit_percent: 5.0
     max_position_duration_minutes: 240
 ml:
   feature_keys:

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -8,19 +8,19 @@ trading:
   - BTC/USD
   - ETH/USD
   - SOL/USD
-  equity_allocation_percent: 15.0
-  max_open_positions: 3
+  eequity_allocation_percent: 10.0
+  max_open_positions: 2
   paper_trading: false
   paper_starting_equity: 200.0
   allow_shorting: false
-  min_cash_per_trade: 10.0
-  max_cash_per_trade: 30.0
-  trade_confidence_min: 0.35
+  min_cash_per_trade: 5.0.0
+  max_cash_per_trade: 10.0.0
+  trade_confidence_min:   0.6
   mode: live
 risk:
-  max_drawdown_percent: 100.0
-  daily_loss_limit_percent: 100.0
-  max_position_duration_minutes: 60
+  max_drawdown_p:ercent 20.0
+  daily_loss_limit_p:ercent 5.0
+    max_position_duration_minutes: 240
 ml:
   feature_keys:
   - momentum_1

--- a/ai_trader/config.yaml
+++ b/ai_trader/config.yaml
@@ -1,7 +1,7 @@
 kraken:
   
-       api_key: ''
-         api_secret: ''
+   api_key: ''
+     api_secret: ''
   rest_rate_limit: 0.5
 trading:
   base_currency: USD

--- a/ai_trader/services/risk.py
+++ b/ai_trader/services/risk.py
@@ -1,4 +1,4 @@
-"""Risk management utilities."""
+"""Risk management utilities with tuned default risk limits for moderate returns."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ class RiskManager:
     """Evaluate trades against configurable risk rules."""
 
     def __init__(self, config: Dict[str, float]) -> None:
-        self._max_drawdown = float(config.get("max_drawdown_percent", 25.0))
+           self._max_drawdown = float(config.get("max_drawdown_percent", 20.0))
         self._daily_loss_limit = float(config.get("daily_loss_limit_percent", 5.0))
         self._max_duration_minutes = float(config.get("max_position_duration_minutes", 240))
         self._daily_anchor = datetime.utcnow().date()


### PR DESCRIPTION
This PR adjusts the bot's configuration for a more realistic 20% monthly compounded return target. Changes include:
- Reduce equity allocation percent to 10% 
- Reduce max open positions to 2 
- Lower min and max cash per trade
- Increase trade confidence threshold
- Adjust risk parameters: max drawdown to 20%, daily loss limit to 5%, max position duration to 240 minutes
- Fix Kraken API config indentation
- Update risk management code defaults