### PR TITLE
Feat: enforce Kraken fees, sizing, and ATR risk controls

### DIFF
--- a/ai_trader/main.py
+++ b/ai_trader/main.py
@@ -629,6 +629,7 @@ async def start_trading(args: argparse.Namespace, config: Dict[str, Any]) -> Non
         paper_trading=paper_mode,
         paper_starting_equity=float(trading_cfg.get("paper_starting_equity", 10000.0)),
         allow_shorting=bool(trading_cfg.get("allow_shorting", False)),
+        fee_rate=float(trading_cfg.get("trade_fee_percent", 0.0)),
     )
 
     trade_log = TradeLog(DB_PATH)
@@ -740,6 +741,7 @@ async def start_trading(args: argparse.Namespace, config: Dict[str, Any]) -> Non
         min_cash_per_trade=float(trading_cfg.get("min_cash_per_trade", 10.0)),
         max_cash_per_trade=float(trading_cfg.get("max_cash_per_trade", 20.0)),
         trade_confidence_min=float(trading_cfg.get("trade_confidence_min", 0.5)),
+        trade_fee_percent=float(trading_cfg.get("trade_fee_percent", 0.0)),
         ml_service=ml_service,
         notifier=notifier,
         runtime_state=runtime_state,

--- a/ai_trader/services/configuration.py
+++ b/ai_trader/services/configuration.py
@@ -185,8 +185,8 @@ def normalize_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     trading_cfg.setdefault("equity_allocation_percent", 2.0)
     trading_cfg.setdefault("paper_starting_equity", 25000.0)
     trading_cfg.setdefault("max_open_positions", 3)
-    trading_cfg.setdefault("min_cash_per_trade", 10.0)
-    trading_cfg.setdefault("max_cash_per_trade", 20.0)
+    trading_cfg.setdefault("min_cash_per_trade", 0.0)
+    trading_cfg.setdefault("max_cash_per_trade", 0.0)
     trading_cfg.setdefault("trade_confidence_min", 0.5)
     raw_symbols = trading_cfg.get("symbols", [])
     normalised_symbols = _normalise_symbol_sequence(raw_symbols)
@@ -203,16 +203,12 @@ def normalize_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     )
     trading_cfg["paper_starting_equity"] = float(trading_cfg.get("paper_starting_equity", 25000.0))
     trading_cfg["max_open_positions"] = int(trading_cfg.get("max_open_positions", 3))
-    min_cash = float(trading_cfg.get("min_cash_per_trade", 10.0))
-    max_cash = float(trading_cfg.get("max_cash_per_trade", 20.0))
-    # Enforce the $10–$20 sizing policy so strategies cannot accidentally
-    # request orders that fall outside the broker-compliant range. Values
-    # outside the bounds are clamped rather than rejected to keep the bot
-    # resilient to misconfiguration during live deployments.
-    min_cash = max(10.0, min(20.0, min_cash))
-    max_cash = max(min_cash, min(20.0, max_cash))
+    min_cash = max(0.0, float(trading_cfg.get("min_cash_per_trade", 0.0)))
+    max_cash_raw = float(trading_cfg.get("max_cash_per_trade", 0.0))
+    max_cash = max(min_cash, max_cash_raw) if max_cash_raw > 0 else max_cash_raw
     trading_cfg["min_cash_per_trade"] = min_cash
     trading_cfg["max_cash_per_trade"] = max_cash
+    trading_cfg["trade_fee_percent"] = float(trading_cfg.get("trade_fee_percent", 0.0))
     confidence_floor = float(trading_cfg.get("trade_confidence_min", 0.5))
     trading_cfg["trade_confidence_min"] = max(0.0, min(1.0, confidence_floor))
     normalised["trading"] = trading_cfg

--- a/ai_trader/services/types.py
+++ b/ai_trader/services/types.py
@@ -59,6 +59,7 @@ class OpenPosition:
     quantity: float
     entry_price: float
     cash_spent: float
+    fees_paid: float = 0.0
     opened_at: datetime = field(default_factory=datetime.utcnow)
 
     def __post_init__(self) -> None:
@@ -67,13 +68,16 @@ class OpenPosition:
         self.quantity = float(self.quantity)
         self.entry_price = float(self.entry_price)
         self.cash_spent = float(self.cash_spent)
+        self.fees_paid = float(self.fees_paid)
 
     def unrealized_pnl(self, last_price: float) -> float:
         """Return the unrealized profit/loss for the position."""
 
         if self.side == "buy":
-            return (last_price - self.entry_price) * self.quantity
-        return (self.entry_price - last_price) * self.quantity
+            gross = (last_price - self.entry_price) * self.quantity
+        else:
+            gross = (self.entry_price - last_price) * self.quantity
+        return gross - self.fees_paid
 
 
 @dataclass(slots=True)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from ai_trader.services.configuration import normalize_config
 
 
@@ -32,7 +34,7 @@ def test_normalize_config_sanitises_symbols() -> None:
 
     assert normalised["trading"]["symbols"] == ["BTC/USD", "SOL/USD", "ETH/USD"]
     assert normalised["trading"]["trade_confidence_min"] == 0.5
-    assert normalised["trading"]["max_cash_per_trade"] == 20.0
+    assert normalised["trading"]["max_cash_per_trade"] == 0.0
 
 
 def test_normalize_config_clamps_trade_size_band() -> None:
@@ -41,8 +43,8 @@ def test_normalize_config_clamps_trade_size_band() -> None:
     normalised = normalize_config(config)
     trading = normalised["trading"]
 
-    assert trading["min_cash_per_trade"] == 10.0
-    assert trading["max_cash_per_trade"] == 20.0
+    assert trading["min_cash_per_trade"] == pytest.approx(2.5)
+    assert trading["max_cash_per_trade"] == pytest.approx(50.0)
 
 
 def test_normalize_config_sets_trading_mode_and_worker_symbols() -> None:

--- a/tests/test_trade_engine.py
+++ b/tests/test_trade_engine.py
@@ -26,11 +26,13 @@ class _DummyBroker:
     starting_equity: float = 10_000.0
     is_paper_trading: bool = True
     base_currency: str = "USD"
+    fee_rate: float = 0.0
 
     def __post_init__(self) -> None:
         self.orders: list[tuple[str, str, float]] = []
         self.reduce_only: list[bool | None] = []
         self.cash_balance: float = float(self.starting_equity)
+        self.min_notional: float = 0.0
 
     async def load_markets(self) -> None:  # pragma: no cover - trivial
         return None
@@ -40,6 +42,13 @@ class _DummyBroker:
 
     async def fetch_balances(self) -> dict[str, float]:
         return {self.base_currency: self.cash_balance}
+
+    async def ensure_market(self, symbol: str) -> None:  # pragma: no cover - trivial
+        _ = symbol
+
+    def min_order_value(self, symbol: str) -> float:  # pragma: no cover - trivial
+        _ = symbol
+        return self.min_notional
 
     async def place_order(
         self,
@@ -54,22 +63,36 @@ class _DummyBroker:
         self.orders.append((symbol, side, float(cash_spent)))
         self.reduce_only.append(reduce_only)
         if side == "buy":
-            self.cash_balance = max(0.0, self.cash_balance - float(cash_spent))
+            fee = float(cash_spent) * self.fee_rate
+            self.cash_balance = max(0.0, self.cash_balance - float(cash_spent) - fee)
         else:
-            self.cash_balance += float(cash_spent)
+            fee = float(cash_spent) * self.fee_rate
+            self.cash_balance += max(0.0, float(cash_spent) - fee)
         return price, quantity
 
     async def close_position(self, symbol: str, side: str, amount: float) -> tuple[float, float]:
-        return 100.0, amount
+        price = 100.0
+        proceeds = price * float(amount)
+        fee = proceeds * self.fee_rate
+        self.cash_balance += max(0.0, proceeds - fee)
+        return price, amount
 
 
 class _DummyWebsocketManager:
-    def __init__(self, symbol: str) -> None:
+    def __init__(self, symbol: str, price: float = 100.0) -> None:
         self._snapshot = MarketSnapshot(
-            prices={symbol: 100.0},
-            history={symbol: [100.0, 101.0, 102.0]},
+            prices={symbol: price},
+            history={symbol: [price, price * 1.01, price * 1.02]},
             candles={
-                symbol: [{"close": 100.0, "open": 99.5, "high": 101.0, "low": 99.0, "volume": 1.0}]
+                symbol: [
+                    {
+                        "close": price,
+                        "open": price * 0.995,
+                        "high": price * 1.01,
+                        "low": price * 0.99,
+                        "volume": 1.0,
+                    }
+                ]
             },
         )
 
@@ -81,6 +104,12 @@ class _DummyWebsocketManager:
 
     def latest_snapshot(self) -> MarketSnapshot:
         return self._snapshot
+
+    def update_price(self, symbol: str, price: float) -> None:
+        self._snapshot.prices[symbol] = price
+        self._snapshot.history[symbol].append(price)
+        candle = self._snapshot.candles[symbol][-1]
+        candle.update({"close": price, "high": max(candle["high"], price), "low": min(candle["low"], price)})
 
 
 class _TestWorker(BaseWorker):
@@ -305,6 +334,68 @@ class _LowConfidenceMLWorker(BaseWorker):
         )
 
 
+class _AtrSizingWorker(BaseWorker):
+    """Worker that exposes ATR metadata so risk sizing can be asserted."""
+
+    name = "AtrSizingWorker"
+
+    def __init__(self, symbol: str, trade_log: TradeLog) -> None:
+        super().__init__([symbol], lookback=3, trade_log=trade_log)
+        self._submitted = False
+
+    async def evaluate_signal(self, snapshot: MarketSnapshot) -> dict[str, str]:
+        self.update_history(snapshot)
+        return {self.symbols[0]: "buy"}
+
+    async def generate_trade(
+        self,
+        symbol: str,
+        signal: str | None,
+        snapshot: MarketSnapshot,
+        equity_per_trade: float,
+        existing_position: OpenPosition | None = None,
+    ) -> TradeIntent | None:
+        price = snapshot.prices[symbol]
+        if existing_position is not None:
+            triggered, reason, risk_meta = self.check_risk_exit(symbol, price)
+            if triggered:
+                self.clear_risk_tracker(symbol)
+                return TradeIntent(
+                    worker=self.name,
+                    action="CLOSE",
+                    symbol=symbol,
+                    side="sell",
+                    cash_spent=existing_position.cash_spent,
+                    entry_price=existing_position.entry_price,
+                    exit_price=price,
+                    confidence=0.0,
+                    reason=reason,
+                    metadata={
+                        "trigger": reason,
+                        **{k: v for k, v in risk_meta.items() if v is not None},
+                    },
+                )
+            return None
+        if self._submitted or signal != "buy":
+            return None
+        self._submitted = True
+        risk_meta = self.prepare_entry_risk(symbol, "buy", price)
+        metadata = {
+            "atr": 1.0,
+            **{k: v for k, v in risk_meta.items() if v is not None},
+        }
+        return TradeIntent(
+            worker=self.name,
+            action="OPEN",
+            symbol=symbol,
+            side="buy",
+            cash_spent=equity_per_trade,
+            entry_price=price,
+            confidence=0.8,
+            metadata=metadata,
+        )
+
+
 async def _run_trade_engine(tmp_path) -> None:
     """The trade engine should execute a simple open/close cycle in paper mode."""
 
@@ -466,13 +557,14 @@ async def _run_engine_with_worker(
     worker_factory: Callable[[TradeLog], BaseWorker],
     *,
     starting_equity: float = 10_000.0,
+    broker_factory: Callable[[], _DummyBroker] | None = None,
 ) -> tuple[list[tuple[str, str, float]], list[Any]]:
     """Run the trade engine with a supplied worker factory and return broker orders."""
 
     db_path = tmp_path / "engine_worker.db"
     trade_log = TradeLog(db_path)
     worker = worker_factory(trade_log)
-    broker = _DummyBroker(starting_equity=starting_equity)
+    broker = broker_factory() if broker_factory else _DummyBroker(starting_equity=starting_equity)
     broker.cash_balance = starting_equity
     websocket_manager = _DummyWebsocketManager("BTC/USD")
     equity_engine = EquityEngine(trade_log, broker.starting_equity)
@@ -522,39 +614,171 @@ def test_trade_engine_casts_string_cash_from_workers(tmp_path) -> None:
     orders, trades = asyncio.run(_run_string_cash_trade(tmp_path))
     assert orders, "Engine should execute at least one order"
     _, _, cash_value = orders[-1]
-    assert cash_value == pytest.approx(10.0)
+    assert cash_value == pytest.approx(3.59)
 
     assert trades, "Trade log should capture the executed order"
     metadata = json.loads(trades[0]["metadata_json"])
-    assert metadata.get("cash_floor_applied") is True
+    assert metadata.get("cash_floor_applied") is None
     assert metadata.get("original_cash_spent") == pytest.approx(3.59)
-    assert metadata.get("min_cash_per_trade") == pytest.approx(10.0)
 
 
-def test_trade_engine_caps_trade_size_to_policy_ceiling(tmp_path) -> None:
-    orders, trades = asyncio.run(
-        _run_engine_with_worker(
-            tmp_path,
-            lambda trade_log: _LargeCashWorker("BTC/USD", trade_log),
+def test_trade_engine_dynamic_sizing_from_risk(tmp_path) -> None:
+    async def runner() -> tuple[_DummyBroker, list[Any]]:
+        db_path = tmp_path / "dynamic_sizing.db"
+        trade_log = TradeLog(db_path)
+        worker = _AtrSizingWorker("BTC/USD", trade_log)
+        broker = _DummyBroker(starting_equity=200.0)
+        broker.min_notional = 1.0
+        websocket_manager = _DummyWebsocketManager("BTC/USD", price=1.0)
+        equity_engine = EquityEngine(trade_log, broker.starting_equity)
+        risk_manager = RiskManager({"risk_per_trade": 0.02, "atr_stop_loss_multiplier": 1.0})
+        engine = TradeEngine(
+            broker=broker,
+            websocket_manager=websocket_manager,
+            workers=[worker],
+            researchers=[],
+            equity_engine=equity_engine,
+            risk_manager=risk_manager,
+            trade_log=trade_log,
+            equity_allocation_percent=100.0,
+            max_open_positions=1,
+            refresh_interval=0.01,
+            paper_trading=True,
+            min_cash_per_trade=0.0,
+            max_cash_per_trade=0.0,
+            trade_fee_percent=0.0,
         )
-    )
-    assert orders, "Engine should submit capped orders"
-    _, _, cash_value = orders[-1]
-    assert cash_value == pytest.approx(20.0)
+        run_task = asyncio.create_task(engine.start())
+        await asyncio.sleep(0.1)
+        await engine.stop()
+        await run_task
+        return broker, list(trade_log.fetch_trades())
 
-    assert trades, "Trade log should record capped fills"
+    broker, trades = asyncio.run(runner())
+    assert broker.orders, "Engine should submit at least one order"
+    _, _, cash_value = broker.orders[-1]
+    assert cash_value == pytest.approx(4.0, rel=1e-2)
+
+    assert trades, "Trade log should capture the executed order"
     metadata = json.loads(trades[0]["metadata_json"])
-    assert metadata.get("cash_cap_applied") is True
-    assert metadata.get("max_cash_per_trade") == pytest.approx(20.0)
-    assert metadata.get("original_cash_spent") == pytest.approx(50.0)
+    assert metadata.get("risk_amount") == pytest.approx(4.0, rel=1e-2)
+
+
+def test_trade_engine_applies_trade_fees(tmp_path) -> None:
+    fee_rate = 0.0026
+
+    async def runner() -> tuple[_DummyBroker, list[Any]]:
+        db_path = tmp_path / "fee_tracking.db"
+        trade_log = TradeLog(db_path)
+        worker = _TestWorker("BTC/USD", trade_log)
+        broker = _DummyBroker(starting_equity=1_000.0, fee_rate=fee_rate)
+        websocket_manager = _DummyWebsocketManager("BTC/USD")
+        equity_engine = EquityEngine(trade_log, broker.starting_equity)
+        risk_manager = RiskManager(
+            {
+                "max_drawdown_percent": 50,
+                "daily_loss_limit_percent": 50,
+                "risk_per_trade": 0.1,
+            }
+        )
+        engine = TradeEngine(
+            broker=broker,
+            websocket_manager=websocket_manager,
+            workers=[worker],
+            researchers=[],
+            equity_engine=equity_engine,
+            risk_manager=risk_manager,
+            trade_log=trade_log,
+            equity_allocation_percent=10.0,
+            max_open_positions=1,
+            refresh_interval=0.01,
+            paper_trading=True,
+            min_cash_per_trade=0.0,
+            max_cash_per_trade=0.0,
+            trade_fee_percent=fee_rate,
+        )
+        run_task = asyncio.create_task(engine.start())
+        await asyncio.sleep(0.2)
+        await engine.stop()
+        await run_task
+        return broker, list(trade_log.fetch_trades())
+
+    broker, trades = asyncio.run(runner())
+    assert broker.orders, "Engine should submit orders with fees applied"
+    assert trades, "Trade log should capture fills"
+    ordered = sorted(trades, key=lambda row: row["timestamp"])
+    open_rows = [row for row in ordered if row["exit_price"] is None]
+    close_rows = [row for row in ordered if row["exit_price"] is not None]
+    assert open_rows and close_rows, "Expected at least one open and one close trade"
+    open_meta = json.loads(open_rows[0]["metadata_json"])
+    close_meta = json.loads(close_rows[0]["metadata_json"])
+    entry_fee = float(open_meta.get("entry_fee", 0.0))
+    exit_fee = float(close_meta.get("exit_fee", 0.0))
+    assert entry_fee == pytest.approx(open_meta["fees_total"], rel=1e-6)
+    expected_exit_fee = close_meta["fill_price"] * close_meta["fill_quantity"] * fee_rate
+    assert exit_fee == pytest.approx(expected_exit_fee, rel=1e-6)
+    assert close_meta["fees_total"] == pytest.approx(entry_fee + exit_fee, rel=1e-6)
+    expected_equity = 1_000.0 - (entry_fee + exit_fee)
+    assert close_meta["pnl_usd"] == pytest.approx(- (entry_fee + exit_fee), rel=1e-6)
+
+
+def test_trade_engine_enforces_atr_stop(tmp_path) -> None:
+    async def runner() -> tuple[_DummyBroker, list[Any]]:
+        db_path = tmp_path / "atr_stop.db"
+        trade_log = TradeLog(db_path)
+        worker = _AtrSizingWorker("BTC/USD", trade_log)
+        broker = _DummyBroker(starting_equity=500.0)
+        websocket_manager = _DummyWebsocketManager("BTC/USD", price=100.0)
+        equity_engine = EquityEngine(trade_log, broker.starting_equity)
+        risk_manager = RiskManager(
+            {
+                "risk_per_trade": 0.05,
+                "atr_stop_loss_multiplier": 1.0,
+                "max_drawdown_percent": 1000.0,
+                "daily_loss_limit_percent": 1000.0,
+            }
+        )
+        engine = TradeEngine(
+            broker=broker,
+            websocket_manager=websocket_manager,
+            workers=[worker],
+            researchers=[],
+            equity_engine=equity_engine,
+            risk_manager=risk_manager,
+            trade_log=trade_log,
+            equity_allocation_percent=50.0,
+            max_open_positions=1,
+            refresh_interval=0.01,
+            paper_trading=True,
+            min_cash_per_trade=0.0,
+            max_cash_per_trade=0.0,
+            trade_fee_percent=0.0,
+        )
+        run_task = asyncio.create_task(engine.start())
+        await asyncio.sleep(0.1)
+        websocket_manager.update_price("BTC/USD", 98.0)
+        await asyncio.sleep(0.2)
+        await engine.stop()
+        await run_task
+        return broker, list(trade_log.fetch_trades())
+
+    broker, trades = asyncio.run(runner())
+    assert broker.orders, "Engine should execute orders"
+    ordered = sorted(trades, key=lambda row: row["timestamp"])
+    close_rows = [row for row in ordered if row["exit_price"] is not None]
+    assert close_rows, "Expected a close trade from ATR stop"
+    close_meta = json.loads(close_rows[0]["metadata_json"])
+    assert close_meta.get("reason") == "stop"
+    assert close_meta.get("stop_price") is not None
 
 
 def test_trade_engine_skips_trades_with_insufficient_balance(tmp_path, caplog) -> None:
     caplog.set_level(logging.INFO)
     orders, trades = asyncio.run(_run_string_cash_trade(tmp_path, starting_equity=5.0))
-    assert orders == []
-    assert trades == []
-    assert "[RISK] Skipped trade for BTC/USD – insufficient funds" in caplog.text
+    assert orders, "Engine should downsize orders to allocation cap"
+    _, _, cash_value = orders[-1]
+    assert cash_value == pytest.approx(0.5)
+    assert trades, "Trade log should capture the executed order"
 
 
 def test_trade_engine_skips_low_confidence_ml_trades(tmp_path, caplog) -> None:

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,0 +1,34 @@
+import asyncio
+import asyncio
+import json
+import logging
+
+import pytest
+
+from ai_trader.broker.websocket_manager import KrakenWebsocketManager
+
+
+class _StubWebsocket:
+    def __init__(self) -> None:
+        self.sent_payloads: list[str] = []
+
+    async def send(self, message: str) -> None:
+        self.sent_payloads.append(message)
+
+
+def test_websocket_manager_expands_aliases_and_normalises_ticks(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    manager = KrakenWebsocketManager(["BTC/USD"])
+    assert manager.symbols == ["BTC/USD"]
+
+    socket = _StubWebsocket()
+    asyncio.run(manager._subscribe(socket))  # type: ignore[attr-defined]
+    assert socket.sent_payloads, "subscription payload should be emitted"
+    payload = json.loads(socket.sent_payloads[-1])
+    assert payload["pair"] == ["XBT/USD"], "Kraken alias should be used when subscribing"
+    assert "Subscribed to Kraken tickers: BTC/USD" in caplog.text
+
+    message = json.dumps([42, {"c": ["27123.45", "1.0"], "v": ["1.0", "2.0"]}, "ticker", "XBT/USD"])
+    manager._handle_message(message)
+    snapshot = manager.latest_snapshot()
+    assert snapshot.prices["BTC/USD"] == pytest.approx(27123.45)


### PR DESCRIPTION
## Summary
- translate Kraken websocket aliases and normalise tick data for configured symbols
- apply configured trade fees to open/close fills, propagate ATR risk to workers, and honour broker min order sizing
- update configuration defaults and add targeted regression coverage for sizing, fees, and websocket handling

## Testing
- pytest tests/test_trade_engine.py tests/test_websocket_manager.py tests/test_configuration.py


------
https://chatgpt.com/codex/tasks/task_e_68d6d7e3f418832f95aedff2052a5db2