### PR TITLE
Enhance ML validation gating and trade metadata

### DIFF
--- a/ai_trader/broker/websocket_manager.py
+++ b/ai_trader/broker/websocket_manager.py
@@ -20,7 +20,9 @@ from ai_trader.services.types import MarketSnapshot
 _NATIVE_TO_DISPLAY: dict[str, str] = {
     "XBT": "BTC",
 }
-_DISPLAY_TO_NATIVE: dict[str, str] = {display: native for native, display in _NATIVE_TO_DISPLAY.items()}
+_DISPLAY_TO_NATIVE: dict[str, str] = {
+    display: native for native, display in _NATIVE_TO_DISPLAY.items()
+}
 
 
 class KrakenWebsocketManager:
@@ -40,12 +42,8 @@ class KrakenWebsocketManager:
         if not normalised:
             raise ValueError("At least one valid Kraken symbol must be provided")
         self._symbols = normalised
-        self._display_to_kraken = {
-            symbol: self._map_to_kraken(symbol) for symbol in self._symbols
-        }
-        self._kraken_to_display = {
-            value: key for key, value in self._display_to_kraken.items()
-        }
+        self._display_to_kraken = {symbol: self._map_to_kraken(symbol) for symbol in self._symbols}
+        self._kraken_to_display = {value: key for key, value in self._display_to_kraken.items()}
         self._history = history
         self._url = "wss://ws.kraken.com/"
         self._latest_prices: Dict[str, float] = {}

--- a/ai_trader/services/schema.py
+++ b/ai_trader/services/schema.py
@@ -24,7 +24,12 @@ TRADE_LOG_TABLES: Dict[str, str] = OrderedDict(
                 pnl_usd REAL,
                 win_loss TEXT,
                 reason TEXT,
-                metadata_json TEXT
+                metadata_json TEXT,
+                confidence REAL,
+                atr_stop REAL,
+                atr_target REAL,
+                atr_value REAL,
+                validation_score REAL
             )
         """,
         "equity_curve": """
@@ -122,7 +127,14 @@ ML_TABLES: Dict[str, str] = OrderedDict(
                 precision REAL,
                 recall REAL,
                 win_rate REAL,
-                support INTEGER
+                support INTEGER,
+                accuracy REAL,
+                f1_score REAL,
+                reward REAL,
+                avg_confidence REAL,
+                threshold REAL,
+                trades INTEGER,
+                window INTEGER
             )
         """,
         "ml_trade_outcomes": """

--- a/ai_trader/services/types.py
+++ b/ai_trader/services/types.py
@@ -33,6 +33,10 @@ class TradeIntent:
     confidence: float = 0.0
     reason: Optional[str] = None
     metadata: Optional[Dict[str, object]] = None
+    atr_stop: Optional[float] = None
+    atr_target: Optional[float] = None
+    atr_value: Optional[float] = None
+    validation_score: Optional[float] = None
     created_at: datetime = field(default_factory=datetime.utcnow)
 
     def __post_init__(self) -> None:
@@ -47,6 +51,14 @@ class TradeIntent:
         if self.pnl_usd is not None:
             self.pnl_usd = float(self.pnl_usd)
         self.confidence = float(self.confidence)
+        if self.atr_stop is not None:
+            self.atr_stop = float(self.atr_stop)
+        if self.atr_target is not None:
+            self.atr_target = float(self.atr_target)
+        if self.atr_value is not None:
+            self.atr_value = float(self.atr_value)
+        if self.validation_score is not None:
+            self.validation_score = float(self.validation_score)
 
 
 @dataclass(slots=True)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -40,7 +40,9 @@ risk:
   max_position_duration_minutes: 240
   risk_per_trade: 0.02
   max_open_positions: 3
-  min_trades_per_day: 30
+  min_trades_per_day:
+    default: 10
+    ETH/USD: 5
   confidence_relax_percent: 0.1
   atr_stop_loss_multiplier: 1.5
   atr_take_profit_multiplier: 2.5
@@ -140,6 +142,19 @@ workers:
         stop_loss_pct: 1.4
         take_profit_pct: 2.4
         trailing_stop_pct: 0.95
+    ensemble_shadow:
+      module: ai_trader.workers.ml_ensemble_worker.EnsembleMLWorker
+      enabled: false
+      display_name: ML Ensemble Shadow
+      emoji: "🧪"
+      symbols:
+        - BTC/USD
+        - ETH/USD
+      parameters:
+        shadow_mode: true
+        validation_min_accuracy: 0.55
+        validation_min_reward: 0.0
+        validation_min_support: 30
 
 researcher:
   module: ai_trader.workers.researcher.MarketResearchWorker

--- a/tests/qa/test_integration_trading_day.py
+++ b/tests/qa/test_integration_trading_day.py
@@ -51,7 +51,7 @@ def test_trading_day_backtest(tmp_path: Path) -> None:
             "daily_loss_limit_percent": 10.0,
             "max_open_positions": 3,
             "confidence_relax_percent": 0.2,
-            "min_trades_per_day": 1,
+            "min_trades_per_day": {"default": 1},
             "min_stop_buffer": 0.001,
         },
         "workers": {

--- a/tests/regression/compare_regression.py
+++ b/tests/regression/compare_regression.py
@@ -35,7 +35,7 @@ CONFIG: Dict[str, Any] = {
         "max_drawdown_percent": 25.0,
         "daily_loss_limit_percent": 10.0,
         "max_open_positions": 3,
-        "min_trades_per_day": 1,
+        "min_trades_per_day": {"default": 1},
         "confidence_relax_percent": 0.2,
         "atr_stop_loss_multiplier": 1.8,
         "atr_take_profit_multiplier": 3.2,

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -30,7 +30,7 @@ def sample_config() -> Dict[str, object]:
             "max_drawdown_percent": 90.0,
             "daily_loss_limit_percent": 90.0,
             "max_open_positions": 5,
-            "min_trades_per_day": 1,
+            "min_trades_per_day": {"default": 1},
             "confidence_relax_percent": 0.5,
             "min_stop_buffer": 0.001,
         },

--- a/tests/test_ensemble_shadow.py
+++ b/tests/test_ensemble_shadow.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ai_trader.services.types import MarketSnapshot
+from ai_trader.workers.ml_ensemble_worker import EnsembleMLWorker
+
+
+class FakeMLService:
+    def __init__(self, metrics: dict[str, dict[str, float]] | None = None) -> None:
+        self._metrics = metrics or {}
+        self.default_threshold = 0.5
+
+    def latest_validation_metrics(self, symbol: str) -> dict[str, float]:
+        return dict(self._metrics.get(symbol, {}))
+
+    def set_metrics(self, symbol: str, metrics: dict[str, float]) -> None:
+        self._metrics[symbol] = metrics
+
+
+@pytest.fixture
+def snapshot() -> MarketSnapshot:
+    return MarketSnapshot(prices={"BTC/USD": 30000.0}, history={}, candles={})
+
+
+def test_shadow_mode_blocks_trades(snapshot: MarketSnapshot) -> None:
+    ml_service = FakeMLService({"BTC/USD": {"accuracy": 0.7, "reward": 0.5, "support": 40}})
+    worker = EnsembleMLWorker(
+        symbols=["BTC/USD"],
+        window_size=40,
+        retrain_interval=10,
+        ml_service=ml_service,
+        shadow_mode=True,
+        validation_min_accuracy=0.6,
+        validation_min_reward=0.1,
+        validation_min_support=20,
+    )
+    worker._latest_prob["BTC/USD"] = 0.85
+    trade = asyncio.run(
+        worker.generate_trade(
+            "BTC/USD", "buy", snapshot, equity_per_trade=1000.0, existing_position=None
+        )
+    )
+    assert trade is None
+
+
+def test_validation_gating(snapshot: MarketSnapshot) -> None:
+    ml_service = FakeMLService({"BTC/USD": {"accuracy": 0.5, "reward": -0.1, "support": 40}})
+    worker = EnsembleMLWorker(
+        symbols=["BTC/USD"],
+        window_size=40,
+        retrain_interval=10,
+        ml_service=ml_service,
+        shadow_mode=False,
+        validation_min_accuracy=0.55,
+        validation_min_reward=0.0,
+        validation_min_support=20,
+    )
+    worker._latest_prob["BTC/USD"] = 0.75
+    blocked_trade = asyncio.run(
+        worker.generate_trade(
+            "BTC/USD", "buy", snapshot, equity_per_trade=1500.0, existing_position=None
+        )
+    )
+    assert blocked_trade is None
+
+    ml_service.set_metrics(
+        "BTC/USD",
+        {"accuracy": 0.72, "reward": 0.35, "support": 45, "avg_confidence": 0.66},
+    )
+    allowed_trade = asyncio.run(
+        worker.generate_trade(
+            "BTC/USD", "buy", snapshot, equity_per_trade=1500.0, existing_position=None
+        )
+    )
+    assert allowed_trade is not None
+    assert allowed_trade.validation_score == pytest.approx(0.35, rel=1e-3)
+    assert allowed_trade.metadata is not None
+    assert "validation_metrics" in allowed_trade.metadata

--- a/tests/test_ml_validation.py
+++ b/tests/test_ml_validation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from ai_trader.api_service import app, attach_services, reset_services
+from ai_trader.services.ml import MLService
+from ai_trader.services.risk import RiskManager
+from ai_trader.services.runtime_state import RuntimeStateStore
+from ai_trader.services.trade_log import MemoryTradeLog
+
+
+def _train_service(db_path: Path) -> MLService:
+    service = MLService(
+        db_path=db_path,
+        feature_keys=["f1"],
+        ensemble=False,
+        threshold=0.5,
+        warmup_samples=5,
+    )
+    for index in range(60):
+        feature_value = float(index % 2)
+        label = index % 2
+        service.update("BTC/USD", {"f1": feature_value}, label=label)
+    return service
+
+
+def test_validation_metrics_exposed_via_api(tmp_path: Path) -> None:
+    db_path = tmp_path / "ml.db"
+    service = _train_service(db_path)
+
+    metrics = service.latest_validation_metrics("BTC/USD")
+    assert metrics
+    assert metrics["accuracy"] >= 0.5
+    assert "reward" in metrics
+
+    state_path = tmp_path / "state.json"
+    reset_services(state_file=state_path)
+    runtime_state = RuntimeStateStore(state_path)
+    attach_services(
+        trade_log=MemoryTradeLog(),
+        runtime_state=runtime_state,
+        risk_manager=RiskManager(),
+        ml_service=service,
+    )
+    client = TestClient(app)
+    try:
+        response = client.get("/ml-metrics")
+        assert response.status_code == 200
+        payload = response.json()
+        assert "metrics" in payload
+        btc_metrics = payload["metrics"].get("BTC/USD")
+        assert btc_metrics is not None
+        assert btc_metrics["accuracy"] >= 0.5
+        assert "reward" in btc_metrics
+    finally:
+        client.close()
+        reset_services(state_file=state_path)

--- a/tests/test_trade_engine.py
+++ b/tests/test_trade_engine.py
@@ -109,7 +109,9 @@ class _DummyWebsocketManager:
         self._snapshot.prices[symbol] = price
         self._snapshot.history[symbol].append(price)
         candle = self._snapshot.candles[symbol][-1]
-        candle.update({"close": price, "high": max(candle["high"], price), "low": min(candle["low"], price)})
+        candle.update(
+            {"close": price, "high": max(candle["high"], price), "low": min(candle["low"], price)}
+        )
 
 
 class _TestWorker(BaseWorker):
@@ -719,7 +721,7 @@ def test_trade_engine_applies_trade_fees(tmp_path) -> None:
     assert exit_fee == pytest.approx(expected_exit_fee, rel=1e-6)
     assert close_meta["fees_total"] == pytest.approx(entry_fee + exit_fee, rel=1e-6)
     expected_equity = 1_000.0 - (entry_fee + exit_fee)
-    assert close_meta["pnl_usd"] == pytest.approx(- (entry_fee + exit_fee), rel=1e-6)
+    assert close_meta["pnl_usd"] == pytest.approx(-(entry_fee + exit_fee), rel=1e-6)
 
 
 def test_trade_engine_enforces_atr_stop(tmp_path) -> None:

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import asyncio
 import json
 import logging
 
@@ -16,7 +15,9 @@ class _StubWebsocket:
         self.sent_payloads.append(message)
 
 
-def test_websocket_manager_expands_aliases_and_normalises_ticks(caplog: pytest.LogCaptureFixture) -> None:
+def test_websocket_manager_expands_aliases_and_normalises_ticks(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     caplog.set_level(logging.INFO)
     manager = KrakenWebsocketManager(["BTC/USD"])
     assert manager.symbols == ["BTC/USD"]


### PR DESCRIPTION
## Summary
- add walk-forward validation storage, API exposure, and Streamlit surfacing for ML metrics
- gate ensemble worker execution behind validation thresholds with optional shadow mode
- persist ATR/validation metadata in the trade log and tune per-symbol confidence relaxation

## Testing
- black .
- flake8 . --max-line-length=100 --exclude=.venv
- pytest -q --maxfail=1 --disable-warnings --timeout=20

------
https://chatgpt.com/codex/tasks/task_e_68d6e107d7b4832fa6cd9b6a81ba97ca