### PR TITLE
Feat: add runtime watchdog and monitoring telemetry

### DIFF
--- a/ai_trader/services/monitoring.py
+++ b/ai_trader/services/monitoring.py
@@ -1,0 +1,152 @@
+"""Centralised monitoring utilities for runtime observability."""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Deque, Iterable, List, Mapping
+
+from ai_trader.services.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class MonitoringEvent:
+    """Structured representation of a monitoring event."""
+
+    timestamp: datetime
+    event_type: str
+    severity: str
+    message: str
+    symbol: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["timestamp"] = self.timestamp.isoformat()
+        if self.metadata is not None:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class MonitoringCenter:
+    """Thread-safe event buffer with JSON logging hooks."""
+
+    def __init__(self, max_events: int = 200) -> None:
+        self._events: Deque[MonitoringEvent] = deque(maxlen=max_events)
+        self._lock = RLock()
+        self._runtime_degraded = False
+        self._degraded_reason: str | None = None
+
+    # ------------------------------------------------------------------
+    # Event management
+    # ------------------------------------------------------------------
+    def record_event(
+        self,
+        event_type: str,
+        severity: str,
+        message: str,
+        *,
+        symbol: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> MonitoringEvent:
+        severity_upper = severity.upper()
+        now = datetime.now(timezone.utc)
+        event = MonitoringEvent(
+            timestamp=now,
+            event_type=event_type,
+            severity=severity_upper,
+            message=message,
+            symbol=symbol,
+            metadata=dict(metadata) if metadata is not None else None,
+        )
+        with self._lock:
+            self._events.appendleft(event)
+        LOGGER.log(
+            self._severity_to_level(severity_upper),
+            json.dumps(
+                {
+                    "timestamp": event.timestamp.isoformat(),
+                    "event_type": event.event_type,
+                    "severity": event.severity,
+                    "symbol": event.symbol,
+                    "message": event.message,
+                    "metadata": dict(metadata) if metadata is not None else None,
+                }
+            ),
+        )
+        return event
+
+    def recent_events(self, limit: int | None = None) -> List[dict[str, object]]:
+        with self._lock:
+            events: Iterable[MonitoringEvent]
+            if limit is None:
+                events = list(self._events)
+            else:
+                events = list(self._events)[:limit]
+        return [event.to_dict() for event in events]
+
+    # ------------------------------------------------------------------
+    # Runtime health state
+    # ------------------------------------------------------------------
+    def set_runtime_degraded(self, degraded: bool, reason: str | None = None) -> None:
+        with self._lock:
+            self._runtime_degraded = degraded
+            self._degraded_reason = reason
+
+    @property
+    def runtime_degraded(self) -> bool:
+        with self._lock:
+            return self._runtime_degraded
+
+    @property
+    def degraded_reason(self) -> str | None:
+        with self._lock:
+            return self._degraded_reason
+
+    def status_flags(self) -> dict[str, object | None]:
+        with self._lock:
+            return {
+                "runtime_degraded": self._runtime_degraded,
+                "reason": self._degraded_reason,
+            }
+
+    # ------------------------------------------------------------------
+    # Test helpers
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        with self._lock:
+            self._events.clear()
+            self._runtime_degraded = False
+            self._degraded_reason = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _severity_to_level(severity: str) -> int:
+        if severity == "CRITICAL":
+            return 50
+        if severity == "ERROR":
+            return 40
+        if severity == "WARNING":
+            return 30
+        if severity == "DEBUG":
+            return 10
+        return 20
+
+
+_MONITORING_CENTER = MonitoringCenter()
+
+
+def get_monitoring_center() -> MonitoringCenter:
+    """Return the singleton monitoring center."""
+
+    return _MONITORING_CENTER
+
+
+__all__ = ["MonitoringCenter", "MonitoringEvent", "get_monitoring_center"]

--- a/ai_trader/services/watchdog.py
+++ b/ai_trader/services/watchdog.py
@@ -1,0 +1,95 @@
+"""Background watchdog monitoring runtime state freshness."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Optional
+
+from ai_trader.services.monitoring import MonitoringCenter, get_monitoring_center
+from ai_trader.services.runtime_state import RuntimeStateStore
+
+
+class RuntimeWatchdog:
+    """Periodically ensure the trading runtime is still updating state."""
+
+    def __init__(
+        self,
+        runtime_state: RuntimeStateStore,
+        *,
+        timeout_seconds: float = 60.0,
+        check_interval: float | None = None,
+        alert_callback: Callable[[float, datetime | None], Awaitable[None]] | None = None,
+        event_loop: asyncio.AbstractEventLoop | None = None,
+        monitoring_center: MonitoringCenter | None = None,
+    ) -> None:
+        self._runtime_state = runtime_state
+        self._timeout = max(1.0, float(timeout_seconds))
+        self._interval = max(0.5, float(check_interval or min(self._timeout / 3.0, 5.0)))
+        self._alert_callback = alert_callback
+        self._loop = event_loop
+        self._monitoring = monitoring_center or get_monitoring_center()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._degraded = False
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, name="runtime-watchdog", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._timeout)
+            self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._interval):
+            last_update = self._runtime_state.last_update_time()
+            now = datetime.now(timezone.utc)
+            stale = last_update is None or (now - last_update).total_seconds() > self._timeout
+            if stale and not self._degraded:
+                self._degraded = True
+                message = f"Bot stalled: no runtime update in {self._timeout:.0f} seconds"
+                self._monitoring.record_event(
+                    "watchdog_stall",
+                    "WARNING",
+                    message,
+                    metadata={
+                        "timeout_seconds": self._timeout,
+                        "last_update_time": last_update.isoformat() if last_update else None,
+                    },
+                )
+                self._monitoring.set_runtime_degraded(True, message)
+                self._dispatch_alert(last_update)
+            elif not stale and self._degraded:
+                self._degraded = False
+                self._monitoring.set_runtime_degraded(False, None)
+                self._monitoring.record_event(
+                    "watchdog_recovered",
+                    "INFO",
+                    "Runtime heartbeat restored",
+                    metadata={
+                        "timeout_seconds": self._timeout,
+                        "last_update_time": (
+                            last_update.isoformat() if last_update is not None else None
+                        ),
+                    },
+                )
+
+    def _dispatch_alert(self, last_update: Optional[datetime]) -> None:
+        if self._alert_callback is None or self._loop is None:
+            return
+        coro = self._alert_callback(self._timeout, last_update)
+        try:
+            asyncio.run_coroutine_threadsafe(coro, self._loop)
+        except RuntimeError:
+            # Event loop already closed; nothing else to do.
+            return
+
+
+__all__ = ["RuntimeWatchdog"]

--- a/tests/test_monitoring_api.py
+++ b/tests/test_monitoring_api.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from ai_trader.api_service import app, attach_services
+from ai_trader.services.monitoring import get_monitoring_center
+from ai_trader.services.risk import RiskManager
+from ai_trader.services.runtime_state import RuntimeStateStore
+from ai_trader.services.trade_log import MemoryTradeLog
+
+
+def test_monitoring_endpoint_surfaces_recent_events() -> None:
+    center = get_monitoring_center()
+    center.reset()
+    runtime_state = RuntimeStateStore(state_file=None)
+    trade_log = MemoryTradeLog()
+    risk_manager = RiskManager()
+    attach_services(trade_log=trade_log, runtime_state=runtime_state, risk_manager=risk_manager)
+
+    center.record_event(
+        "watchdog_stall",
+        "WARNING",
+        "Runtime stalled",
+        metadata={"timeout_seconds": 60},
+    )
+    center.set_runtime_degraded(True, "Runtime stalled")
+
+    client = TestClient(app)
+    response = client.get("/monitoring")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["events"][0]["event_type"] == "watchdog_stall"
+
+    status_response = client.get("/status")
+    assert status_response.status_code == 200
+    status_payload = status_response.json()
+    assert status_payload["runtime_degraded"] is True
+    assert status_payload["runtime_degraded_reason"] == "Runtime stalled"

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,47 @@
+import asyncio
+
+from ai_trader.services.monitoring import get_monitoring_center
+from ai_trader.services.runtime_state import RuntimeStateStore
+from ai_trader.services.watchdog import RuntimeWatchdog
+
+
+class _DummyNotifier:
+    def __init__(self) -> None:
+        self.alerts: list[tuple[float, object]] = []
+
+    async def send_watchdog_alert(self, timeout_seconds: float, last_update: object) -> None:
+        self.alerts.append((timeout_seconds, last_update))
+
+
+def test_watchdog_detects_stall_and_recovers() -> None:
+    center = get_monitoring_center()
+    center.reset()
+    runtime_state = RuntimeStateStore(state_file=None)
+    runtime_state.mark_runtime_update()
+    notifier = _DummyNotifier()
+
+    async def _runner() -> tuple[list[tuple[float, object]], dict[str, object | None]]:
+        watchdog = RuntimeWatchdog(
+            runtime_state,
+            timeout_seconds=1.0,
+            check_interval=0.2,
+            alert_callback=notifier.send_watchdog_alert,
+            event_loop=asyncio.get_running_loop(),
+            monitoring_center=center,
+        )
+        watchdog.start()
+        await asyncio.sleep(1.3)
+        runtime_state.mark_runtime_update()
+        await asyncio.sleep(0.4)
+        watchdog.stop()
+        return notifier.alerts, center.status_flags()
+
+    alerts, status = asyncio.run(_runner())
+
+    assert alerts, "watchdog should emit alert when runtime stalls"
+    assert status["runtime_degraded"] is False
+    events = center.recent_events()
+    stall_events = [event for event in events if event["event_type"] == "watchdog_stall"]
+    recovery_events = [event for event in events if event["event_type"] == "watchdog_recovered"]
+    assert stall_events, "watchdog should log stall event"
+    assert recovery_events, "watchdog should log recovery event"

--- a/tests/test_websocket_reconnect.py
+++ b/tests/test_websocket_reconnect.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Callable
+
+import pytest
+
+from ai_trader.broker.websocket_manager import KrakenWebsocketManager
+from ai_trader.services.monitoring import get_monitoring_center
+
+
+class _DummyConnection:
+    def __init__(
+        self,
+        messages: list[str],
+        *,
+        drop: bool,
+        on_complete: Callable[[], None] | None = None,
+    ) -> None:
+        self._messages: deque[str] = deque(messages)
+        self._drop = drop
+        self._on_complete = on_complete
+        self.sent: list[str] = []
+
+    async def __aenter__(self) -> "_DummyConnection":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    def __aiter__(self) -> "_DummyConnection":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._messages:
+            return self._messages.popleft()
+        if self._drop:
+            self._drop = False
+            raise ConnectionError("connection dropped")
+        if self._on_complete is not None:
+            self._on_complete()
+        raise StopAsyncIteration
+
+
+def _ticker_message(price: float) -> str:
+    payload = [
+        42,
+        {"c": [f"{price:.2f}", "1.0"], "v": ["1.0", "2.0"]},
+        "ticker",
+        "XBT/USD",
+    ]
+    return json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_websocket_manager_recovers_after_drop() -> None:
+    center = get_monitoring_center()
+    center.reset()
+    attempts = 0
+    stop_trigger: Callable[[], None] = lambda: None
+
+    def _connector(url: str, ping_interval: int = 20) -> _DummyConnection:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return _DummyConnection([_ticker_message(27123.45)], drop=True)
+        return _DummyConnection(
+            [_ticker_message(27130.10)],
+            drop=False,
+            on_complete=stop_trigger,
+        )
+
+    manager = KrakenWebsocketManager(
+        ["BTC/USD"],
+        connector=_connector,
+        reconnect_base_delay=0.01,
+        reconnect_max_delay=0.02,
+    )
+    stop_trigger = manager._stop_event.set  # type: ignore[attr-defined]
+
+    await manager.start()
+    await asyncio.sleep(0.2)
+    await manager.stop()
+
+    snapshot = manager.latest_snapshot()
+    assert snapshot.prices["BTC/USD"] == pytest.approx(27130.10)
+    events = center.recent_events()
+    reconnect_events = [event for event in events if event["event_type"] == "websocket_reconnect"]
+    assert reconnect_events, "reconnect attempts should be logged"
+
+
+def test_candle_rollover_handles_malformed_volume() -> None:
+    center = get_monitoring_center()
+    center.reset()
+    manager = KrakenWebsocketManager(["BTC/USD"], candle_interval_seconds=1)
+    now = datetime.utcnow()
+    manager._update_candle("BTC/USD", 100.0, 1.0, now)
+    manager._update_candle("BTC/USD", 101.0, "bad-volume", now + timedelta(seconds=1))
+    candles = manager.latest_snapshot().candles["BTC/USD"]
+    assert candles, "candle history should be populated"
+    first = candles[-1]
+    assert first["open"] == pytest.approx(100.0)
+    assert first["close"] == pytest.approx(100.0)


### PR DESCRIPTION
## Summary
- add a monitoring center with JSON structured logging and expose it via a new /monitoring API endpoint
- introduce a runtime watchdog plus Telegram startup heartbeat and watchdog alerts wired through the notifier
- harden the Kraken websocket manager with exponential backoff, jitter, and safer candle rollovers while recording reconnect telemetry
- document new monitoring controls and add tests for watchdog, notifier startup heartbeat, websocket reconnection, and monitoring API

## Testing
- black .
- flake8 . --max-line-length=100 --exclude=.venv
- pytest -q --maxfail=1 --disable-warnings --timeout=20


------
https://chatgpt.com/codex/tasks/task_e_68d6e966be74832f99339f0d938b32cc