### PR TITLE
Feat: persist risk config revisions and sync engine

### DIFF
--- a/ai_trader/services/schema.py
+++ b/ai_trader/services/schema.py
@@ -83,6 +83,14 @@ TRADE_LOG_TABLES: Dict[str, str] = OrderedDict(
                 updated_at TEXT NOT NULL
             )
         """,
+        "risk_settings": """
+            CREATE TABLE IF NOT EXISTS risk_settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                revision INTEGER NOT NULL UNIQUE,
+                settings_json TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """,
         "trade_events": """
             CREATE TABLE IF NOT EXISTS trade_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/qa/test_api_endpoints_qa.py
+++ b/tests/qa/test_api_endpoints_qa.py
@@ -106,6 +106,7 @@ def test_trades_and_risk_endpoints(api_client: TestClient, tmp_path: Path) -> No
     assert risk_response.status_code == 200
     risk_payload = risk_response.json()
     assert "risk_per_trade" in risk_payload
+    assert "revision" in risk_payload
 
 
 def test_update_config_endpoint(api_client: TestClient, tmp_path: Path) -> None:
@@ -121,7 +122,9 @@ def test_update_config_endpoint(api_client: TestClient, tmp_path: Path) -> None:
     payload = response.json()
     assert payload["config"]["risk_per_trade"] == pytest.approx(0.05)
     assert payload["config"]["max_open_positions"] == 4
+    assert payload["revision"] >= 1
 
     # ensure runtime state persisted the update
     latest = runtime_state.risk_snapshot()
     assert latest["risk_per_trade"] == pytest.approx(0.05)
+    assert latest["revision"] == payload["revision"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ def api_context() -> tuple[TestClient, RuntimeStateStore, RiskManager, MemoryTra
     )
     runtime_state.set_base_currency("USD")
     runtime_state.set_starting_equity(1000.0)
-    runtime_state.update_risk_settings(risk_manager.config_dict())
+    runtime_state.update_risk_settings(risk_manager.config_dict(), revision=0)
     attach_services(trade_log=trade_log, runtime_state=runtime_state, risk_manager=risk_manager)
 
     # Seed trade history for the API responses.
@@ -137,6 +137,8 @@ def test_config_updates_risk_settings(
     payload = response.json()
     assert pytest.approx(payload["config"]["risk_per_trade"], rel=1e-6) == 0.05
     assert pytest.approx(risk_manager.config_dict()["risk_per_trade"], rel=1e-6) == 0.05
+    assert payload["revision"] >= 1
     risk_snapshot = runtime_state.risk_snapshot()
     assert pytest.approx(risk_snapshot["risk_per_trade"], rel=1e-6) == 0.05
     assert pytest.approx(risk_snapshot["max_drawdown_percent"], rel=1e-6) == 15.0
+    assert risk_snapshot["revision"] == payload["revision"]


### PR DESCRIPTION
## Summary
- persist risk configuration updates to a dedicated risk_settings table and expose revision metadata through the API/runtime state
- teach the trade engine to poll the persisted risk revision and refresh its RiskManager configuration when changes land
- cover the new behaviour with API assertions and an engine integration test that simulates an API-driven update

## Testing
- pytest tests/test_api.py
- pytest tests/qa/test_api_endpoints_qa.py
- pytest tests/test_trade_engine.py::test_trade_engine_applies_persisted_risk_updates

------
https://chatgpt.com/codex/tasks/task_e_68d703ba9d98832fbcbd39078f246660