### PR TITLE
Add SwiftUI dashboards backed by reporting API

### DIFF
--- a/ios/AidayTradingApp/README.md
+++ b/ios/AidayTradingApp/README.md
@@ -11,6 +11,7 @@ This SwiftUI application provides the secure mobile entry point for the AidayTra
 - Role-based UI that surfaces Admin tooling only for approved administrators.
 - Sensitive screen protections including Face ID / Touch ID gating, idle-timeout logout, and screen capture monitoring.
 - Unit and integration tests covering authentication, token handling, role detection, and approval workflow.
+- Viewer dashboards with equity charts, calendar PnL heatmap, and a paginated trade ledger consuming `/api/v1` reporting endpoints.
 
 ## Project structure
 
@@ -100,3 +101,4 @@ xcodebuild test
 - Wire dashboard, calendar, and trade list views to live backend data.
 - Extend admin tooling with approval actions (approve/reject users, manage risk limits).
 - Add push notification support for approval status changes.
+- Expand dashboard analytics with additional strategy drill-downs.

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/CalendarDashboardViewModel.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/CalendarDashboardViewModel.swift
@@ -1,0 +1,134 @@
+import Foundation
+import SwiftUI
+
+struct CalendarDayCell: Identifiable {
+    let id = UUID()
+    let date: Date?
+    let isCurrentMonth: Bool
+    let pnl: Decimal?
+    let trades: [TradeRecord]
+}
+
+@MainActor
+final class CalendarDashboardViewModel: ObservableObject {
+    @Published var month: Date
+    @Published var dayCells: [CalendarDayCell] = []
+    @Published var selectedDay: CalendarDayCell?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let accessToken: String
+    private let reportingService: ReportingServiceProtocol
+    private let calendar: Calendar
+    private let centralTimeZone = TimeZone(identifier: "America/Chicago")!
+
+    init(month: Date = Date(), accessToken: String, reportingService: ReportingServiceProtocol) {
+        self.month = month
+        self.accessToken = accessToken
+        self.reportingService = reportingService
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = centralTimeZone
+        self.calendar = calendar
+    }
+
+    func loadMonth() async {
+        isLoading = true
+        errorMessage = nil
+        selectedDay = nil
+        do {
+            let range = monthBoundary(for: month)
+            var trades: [TradeRecord] = []
+            var page = 1
+            let pageSize = 200
+            while true {
+                let pageResponse = try await reportingService.fetchTrades(
+                    accessToken: accessToken,
+                    page: page,
+                    pageSize: pageSize,
+                    symbol: nil,
+                    side: nil,
+                    start: range.start,
+                    end: range.end
+                )
+                trades.append(contentsOf: pageResponse.items)
+                if trades.count >= pageResponse.total || pageResponse.items.count < pageSize {
+                    break
+                }
+                page += 1
+            }
+            let grouped = groupTradesByDay(trades: trades)
+            dayCells = buildCalendarCells(range: range, grouped: grouped)
+        } catch {
+            errorMessage = (error as? APIErrorResponse)?.message ?? error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func goToPreviousMonth() {
+        if let newMonth = calendar.date(byAdding: .month, value: -1, to: month) {
+            month = newMonth
+        }
+    }
+
+    func goToNextMonth() {
+        if let newMonth = calendar.date(byAdding: .month, value: 1, to: month) {
+            month = newMonth
+        }
+    }
+
+    private func monthBoundary(for date: Date) -> (start: Date, end: Date) {
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: date))!
+        let startOfNextMonth = calendar.date(byAdding: DateComponents(month: 1), to: startOfMonth)!
+        return (startOfMonth, startOfNextMonth)
+    }
+
+    private func groupTradesByDay(trades: [TradeRecord]) -> [Date: (pnl: Decimal, trades: [TradeRecord])] {
+        trades.reduce(into: [:]) { partialResult, trade in
+            let day = calendar.startOfDay(for: trade.timestamp)
+            var entry = partialResult[day] ?? (pnl: 0, trades: [])
+            entry.pnl += trade.pnl
+            entry.trades.append(trade)
+            partialResult[day] = entry
+        }
+    }
+
+    private func buildCalendarCells(
+        range: (start: Date, end: Date),
+        grouped: [Date: (pnl: Decimal, trades: [TradeRecord])]
+    ) -> [CalendarDayCell] {
+        let daysInMonth = calendar.range(of: .day, in: .month, for: range.start) ?? 1..<31
+        let firstWeekday = calendar.component(.weekday, from: range.start)
+        let leadingEmpty = (firstWeekday + 6) % 7
+        var cells: [CalendarDayCell] = []
+        cells.reserveCapacity(leadingEmpty + daysInMonth.count)
+
+        if leadingEmpty > 0 {
+            for _ in 0..<leadingEmpty {
+                cells.append(CalendarDayCell(date: nil, isCurrentMonth: false, pnl: nil, trades: []))
+            }
+        }
+
+        for day in daysInMonth {
+            guard let date = calendar.date(byAdding: .day, value: day - 1, to: range.start) else { continue }
+            let dayKey = calendar.startOfDay(for: date)
+            let payload = grouped[dayKey]
+            cells.append(
+                CalendarDayCell(
+                    date: date,
+                    isCurrentMonth: true,
+                    pnl: payload?.pnl,
+                    trades: payload?.trades.sorted(by: { $0.timestamp < $1.timestamp }) ?? []
+                )
+            )
+        }
+
+        let totalCells = cells.count
+        let remainder = totalCells % 7
+        if remainder != 0 {
+            for _ in 0..<(7 - remainder) {
+                cells.append(CalendarDayCell(date: nil, isCurrentMonth: false, pnl: nil, trades: []))
+            }
+        }
+        return cells
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/CalendarView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/CalendarView.swift
@@ -1,17 +1,254 @@
 import SwiftUI
 
 struct CalendarView: View {
+    let context: UserSessionContext
+    @StateObject private var viewModel: CalendarDashboardViewModel
+
+    init(context: UserSessionContext, reportingService: ReportingServiceProtocol) {
+        self.context = context
+        _viewModel = StateObject(
+            wrappedValue: CalendarDashboardViewModel(
+                month: Date(),
+                accessToken: context.tokens.accessToken,
+                reportingService: reportingService
+            )
+        )
+    }
+
+    init(context: UserSessionContext, viewModel: CalendarDashboardViewModel) {
+        self.context = context
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 16) {
-                Image(systemName: "calendar")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.accent)
-                Text("Calendar integrations coming soon.")
-                    .font(.body)
+                header
+                calendarGrid
             }
             .padding()
-            .navigationTitle("Calendar")
+            .background(Theme.background.ignoresSafeArea())
+            .navigationTitle("PnL Calendar")
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(Theme.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .task {
+                await viewModel.loadMonth()
+            }
+            .onChange(of: viewModel.month) { _, newMonth in
+                Task {
+                    await viewModel.loadMonth()
+                }
+            }
+            .sheet(item: $viewModel.selectedDay) { day in
+                TradeListSheet(day: day)
+            }
+            .overlay(alignment: .bottom) {
+                if let error = viewModel.errorMessage {
+                    errorBanner(message: error)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private var header: some View {
+        HStack {
+            Button {
+                viewModel.goToPreviousMonth()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.headline)
+                    .padding(8)
+                    .background(Theme.cardBackground.opacity(0.6), in: Circle())
+            }
+
+            Spacer()
+
+            Text(DateFormatter.monthYear.string(from: viewModel.month))
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.white)
+                .contentTransition(.opacity)
+
+            Spacer()
+
+            Button {
+                viewModel.goToNextMonth()
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.headline)
+                    .padding(8)
+                    .background(Theme.cardBackground.opacity(0.6), in: Circle())
+            }
         }
     }
+
+    private var calendarGrid: some View {
+        VStack(spacing: 12) {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 7), spacing: 8) {
+                ForEach(Calendar.current.shortWeekdaySymbols, id: \.self) { symbol in
+                    Text(symbol)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                if viewModel.isLoading {
+                    ForEach(0..<42, id: \.self) { _ in
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Theme.cardBackground.opacity(0.4))
+                            .frame(height: 44)
+                            .redacted(reason: .placeholder)
+                    }
+                } else {
+                    ForEach(viewModel.dayCells) { cell in
+                        DayCellView(cell: cell)
+                            .onTapGesture {
+                                guard cell.date != nil, !cell.trades.isEmpty else { return }
+                                viewModel.selectedDay = cell
+                            }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorBanner(message: String) -> some View {
+        Text(message)
+            .font(.footnote)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Theme.accentRed.opacity(0.9))
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding()
+    }
+}
+
+private struct DayCellView: View {
+    let cell: CalendarDayCell
+    private let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.maximumFractionDigits = 0
+        formatter.currencyCode = "USD"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(spacing: 6) {
+            if let date = cell.date {
+                Text(DateFormatter.dayFormatter.string(from: date))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.white)
+                if let pnl = cell.pnl {
+                    Text(formatter.string(from: NSDecimalNumber(decimal: pnl)) ?? "")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(color(for: pnl))
+                } else {
+                    Text("—")
+                        .font(.caption2)
+                        .foregroundStyle(.white.opacity(0.4))
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(borderColor, lineWidth: 1)
+        )
+    }
+
+    private var backgroundColor: Color {
+        guard let pnl = cell.pnl, cell.date != nil else {
+            return Theme.cardBackground.opacity(0.35)
+        }
+        let base = color(for: pnl)
+        return base.opacity(0.15)
+    }
+
+    private var borderColor: Color {
+        guard let pnl = cell.pnl, cell.date != nil else {
+            return Color.white.opacity(0.1)
+        }
+        return color(for: pnl).opacity(0.4)
+    }
+
+    private func color(for pnl: Decimal) -> Color {
+        if pnl > 0 {
+            return Theme.accentGreen
+        } else if pnl < 0 {
+            return Theme.accentRed
+        }
+        return .white.opacity(0.7)
+    }
+}
+
+private struct TradeListSheet: View {
+    let day: CalendarDayCell
+    @Environment(\.dismiss) private var dismiss
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        NavigationStack {
+            List(day.trades) { trade in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(trade.symbol)
+                            .font(.headline)
+                        Spacer()
+                        Text(trade.pnl >= 0 ? "Win" : "Loss")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(trade.pnl >= 0 ? Theme.accentGreen : Theme.accentRed)
+                    }
+                    Text("Side: \(trade.side.rawValue.uppercased())")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Size: \(trade.size.doubleValue, format: .number.precision(.fractionLength(2)))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(dateFormatter.string(from: trade.timestamp))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+            .navigationTitle(day.date.map { DateFormatter.mediumFormatter.string(from: $0) } ?? "Trades")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension DateFormatter {
+    static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d"
+        return formatter
+    }()
+
+    static let mediumFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    static let monthYear: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "LLLL yyyy"
+        return formatter
+    }()
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeDashboardViewModel.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeDashboardViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class HomeDashboardViewModel: ObservableObject {
+    @Published var equitySeries: [EquityCurvePoint] = []
+    @Published var profitSummary: ProfitSummary?
+    @Published var systemStatus: SystemStatus?
+    @Published var balance: Decimal?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let accessToken: String
+    private let reportingService: ReportingServiceProtocol
+    private var refreshTask: Task<Void, Never>?
+
+    init(accessToken: String, reportingService: ReportingServiceProtocol) {
+        self.accessToken = accessToken
+        self.reportingService = reportingService
+    }
+
+    func start() {
+        guard refreshTask == nil else { return }
+        refreshTask = Task { [weak self] in
+            await self?.loadData()
+            while !(Task.isCancelled) {
+                try? await Task.sleep(nanoseconds: 600 * 1_000_000_000)
+                await self?.loadData()
+            }
+        }
+    }
+
+    func stop() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    deinit {
+        refreshTask?.cancel()
+    }
+
+    func loadData() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            async let statusTask: SystemStatus = try await reportingService.fetchSystemStatus(accessToken: accessToken)
+            async let equityTask: [EquityCurvePoint] = try await reportingService.fetchEquityCurve(accessToken: accessToken, start: nil, end: nil, limit: 120)
+            async let balanceTask: Decimal = try await reportingService.fetchCurrentBalance(accessToken: accessToken)
+
+            let profit = try await reportingService.fetchProfitSummary(accessToken: accessToken)
+            let status = try await statusTask
+            let equity = try await equityTask
+            let balanceValue = (try? await balanceTask) ?? profit.currentBalance
+            systemStatus = status
+            profitSummary = profit
+            balance = balanceValue
+            equitySeries = equity.sorted(by: { $0.timestamp < $1.timestamp })
+        } catch {
+            errorMessage = (error as? APIErrorResponse)?.message ?? error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeView.swift
@@ -1,18 +1,210 @@
+import Charts
 import SwiftUI
 
 struct HomeView: View {
+    let context: UserSessionContext
+    @StateObject private var viewModel: HomeDashboardViewModel
+
+    init(context: UserSessionContext, reportingService: ReportingServiceProtocol) {
+        self.context = context
+        _viewModel = StateObject(wrappedValue: HomeDashboardViewModel(accessToken: context.tokens.accessToken, reportingService: reportingService))
+    }
+
+    init(context: UserSessionContext, viewModel: HomeDashboardViewModel) {
+        self.context = context
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("Dashboards")
-                    .font(.title2)
-                    .bold()
-                Text("Connects to backend metrics once available.")
-                    .font(.body)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    equitySection
+                    metricsSection
+                    statusSection
+                }
+                .padding()
+            }
+            .background(Theme.background.ignoresSafeArea())
+            .navigationTitle("Equity & PnL")
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(Theme.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .task {
+                viewModel.start()
+            }
+            .onDisappear {
+                viewModel.stop()
+            }
+            .overlay(alignment: .bottom) {
+                if let error = viewModel.errorMessage {
+                    errorBanner(message: error)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private var equitySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Label("Equity Curve", systemImage: "waveform.path.ecg")
+                    .font(.title3.weight(.bold))
+                Spacer()
+                if viewModel.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                }
+            }
+            .foregroundStyle(.white)
+
+            if viewModel.equitySeries.isEmpty {
+                Text("No equity data available yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.white.opacity(0.7))
+            } else {
+                Chart(viewModel.equitySeries) { point in
+                    LineMark(
+                        x: .value("Time", point.timestamp),
+                        y: .value("Equity", point.equity.doubleValue)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(.linearGradient(
+                        Gradient(colors: [Theme.accentGreen.opacity(0.9), Theme.accentGreen.opacity(0.3)]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ))
+
+                    AreaMark(
+                        x: .value("Time", point.timestamp),
+                        y: .value("Equity", point.equity.doubleValue)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(.linearGradient(
+                        Gradient(colors: [Theme.accentGreen.opacity(0.35), Theme.accentGreen.opacity(0.05)]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ))
+                }
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                        AxisGridLine().foregroundStyle(.white.opacity(0.1))
+                        AxisValueLabel(format: .dateTime.hour().minute(), centered: true)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                        AxisGridLine().foregroundStyle(.white.opacity(0.1))
+                        if let doubleValue = value.as(Double.self) {
+                            let formatted = DashboardFormatters.currency.string(from: NSNumber(value: doubleValue)) ?? ""
+                            AxisValueLabel(formatted)
+                                .foregroundStyle(.white.opacity(0.7))
+                        }
+                    }
+                }
+                .frame(minHeight: 220)
+                .dashboardCardStyle()
+            }
+        }
+    }
+
+    private var metricsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Performance Snapshot")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.white)
+
+            HStack(spacing: 16) {
+                metricCard(title: "Balance", value: formattedCurrency(viewModel.balance ?? viewModel.profitSummary?.currentBalance))
+                metricCard(title: "P/L", value: profitValueText)
+                metricCard(title: "Win Rate", value: winRateText)
+            }
+        }
+    }
+
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Trading Status")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.white)
+            HStack {
+                if let status = viewModel.systemStatus {
+                    Label(status.running ? "Running" : "Stopped", systemImage: status.running ? "play.fill" : "pause.fill")
+                        .font(.headline)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background(status.running ? Theme.accentGreen.opacity(0.2) : Theme.accentRed.opacity(0.2))
+                        .foregroundStyle(status.running ? Theme.accentGreen : Theme.accentRed)
+                        .clipShape(Capsule())
+                    if status.uptimeSeconds > 0 {
+                        Text("Uptime: \(formatDuration(status.uptimeSeconds))")
+                            .font(.subheadline)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                } else if viewModel.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text("Status unavailable")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.6))
+                }
                 Spacer()
             }
-            .padding()
-            .navigationTitle("Overview")
+            .dashboardCardStyle()
         }
+    }
+
+    private func metricCard(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.6))
+            Text(value)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.white)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .dashboardCardStyle()
+    }
+
+    private var profitValueText: String {
+        guard let summary = viewModel.profitSummary else { return "—" }
+        let amount = formattedCurrency(summary.totalPLAmount)
+        let percent = DashboardFormatters.percent.string(from: NSNumber(value: summary.totalPLPercent.doubleValue / 100)) ?? ""
+        return "\(amount) (\(percent))"
+    }
+
+    private var winRateText: String {
+        guard let summary = viewModel.profitSummary else { return "—" }
+        let formatted = DashboardFormatters.percent.string(from: NSNumber(value: summary.winRate)) ?? ""
+        return formatted
+    }
+
+    private func formattedCurrency(_ value: Decimal?) -> String {
+        guard let value else { return "—" }
+        return DashboardFormatters.currency.string(from: NSDecimalNumber(decimal: value)) ?? "—"
+    }
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    @ViewBuilder
+    private func errorBanner(message: String) -> some View {
+        Text(message)
+            .font(.footnote)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Theme.accentRed.opacity(0.9))
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding()
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainTabView: View {
     let context: UserSessionContext
+    private let reportingService: ReportingServiceProtocol
     @EnvironmentObject private var session: SessionStore
 
     enum Tab: Hashable {
@@ -13,21 +14,26 @@ struct MainTabView: View {
 
     @State private var selection: Tab = .home
 
+    init(context: UserSessionContext, reportingService: ReportingServiceProtocol = ReportingService()) {
+        self.context = context
+        self.reportingService = reportingService
+    }
+
     var body: some View {
         TabView(selection: $selection) {
-            HomeView()
+            HomeView(context: context, reportingService: reportingService)
                 .tabItem {
                     Label("Home", systemImage: "chart.line.uptrend.xyaxis")
                 }
                 .tag(Tab.home)
 
-            CalendarView()
+            CalendarView(context: context, reportingService: reportingService)
                 .tabItem {
                     Label("Calendar", systemImage: "calendar")
                 }
                 .tag(Tab.calendar)
 
-            TradesView()
+            TradesView(context: context, reportingService: reportingService)
                 .tabItem {
                     Label("Trades", systemImage: "list.bullet.rectangle")
                 }
@@ -42,6 +48,7 @@ struct MainTabView: View {
             }
         }
         .sensitive()
+        .tint(Theme.accentGreen)
         .onChange(of: selection) { _, _ in
             session.registerInteraction()
         }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesView.swift
@@ -1,14 +1,183 @@
 import SwiftUI
 
 struct TradesView: View {
+    let context: UserSessionContext
+    @StateObject private var viewModel: TradesViewModel
+    @State private var symbolDebounceTask: Task<Void, Never>?
+
+    init(context: UserSessionContext, reportingService: ReportingServiceProtocol) {
+        self.context = context
+        _viewModel = StateObject(wrappedValue: TradesViewModel(accessToken: context.tokens.accessToken, reportingService: reportingService))
+    }
+
+    init(context: UserSessionContext, viewModel: TradesViewModel) {
+        self.context = context
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
         NavigationStack {
-            List {
-                Section("Recent trades") {
-                    Text("Once connected, this list will show executed trades.")
+            VStack(spacing: 16) {
+                filterControls
+                tradesList
+            }
+            .padding()
+            .background(Theme.background.ignoresSafeArea())
+            .navigationTitle("Trades")
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(Theme.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .task {
+                await viewModel.loadInitial()
+            }
+            .onChange(of: viewModel.symbolFilter) { _, _ in
+                symbolDebounceTask?.cancel()
+                symbolDebounceTask = Task { [symbol = viewModel.symbolFilter] in
+                    try? await Task.sleep(nanoseconds: 350_000_000)
+                    await MainActor.run {
+                        if symbol == viewModel.symbolFilter {
+                            Task { await viewModel.loadInitial() }
+                        }
+                    }
                 }
             }
-            .navigationTitle("Trades")
+            .onChange(of: viewModel.outcomeFilter) { _, _ in
+                Task { await viewModel.loadInitial() }
+            }
+            .overlay(alignment: .bottom) {
+                if let error = viewModel.errorMessage {
+                    errorBanner(message: error)
+                }
+            }
         }
+        .preferredColorScheme(.dark)
+    }
+
+    private var filterControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Filters")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.6))
+            HStack(spacing: 12) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.white.opacity(0.6))
+                    TextField("Symbol", text: $viewModel.symbolFilter)
+                        .textInputAutocapitalization(.characters)
+                        .disableAutocorrection(true)
+                        .foregroundStyle(.white)
+                }
+                .padding(12)
+                .background(Theme.cardBackground.cornerRadius(12))
+
+                Picker("Outcome", selection: $viewModel.outcomeFilter) {
+                    ForEach(TradeOutcomeFilter.allCases) { option in
+                        Text(option.title).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .background(Theme.cardBackground.opacity(0.4).cornerRadius(12))
+            }
+        }
+    }
+
+    private var tradesList: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(viewModel.filteredTrades) { trade in
+                    TradeRow(trade: trade)
+                        .onAppear {
+                            if trade.id == viewModel.filteredTrades.last?.id {
+                                Task { await viewModel.loadMore() }
+                            }
+                        }
+                }
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                        .padding()
+                } else if viewModel.filteredTrades.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "tray")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.white.opacity(0.4))
+                        Text("No trades match the selected filters yet.")
+                            .font(.footnote)
+                            .foregroundStyle(.white.opacity(0.6))
+                    }
+                    .padding(.top, 32)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorBanner(message: String) -> some View {
+        Text(message)
+            .font(.footnote)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Theme.accentRed.opacity(0.9))
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding()
+    }
+}
+
+private struct TradeRow: View {
+    let trade: TradeRecord
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(trade.symbol)
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(.white)
+                    Text(dateFormatter.string(from: trade.timestamp))
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+                Spacer()
+                Text(trade.pnl >= 0 ? "Win" : "Loss")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(trade.pnl >= 0 ? Theme.accentGreen : Theme.accentRed)
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .background((trade.pnl >= 0 ? Theme.accentGreen : Theme.accentRed).opacity(0.15), in: Capsule())
+            }
+
+            HStack {
+                Label("Side: \(trade.side.rawValue.uppercased())", systemImage: "arrow.left.arrow.right")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+                Spacer()
+                Label(
+                    "Size: \(trade.size.doubleValue, format: .number.precision(.fractionLength(2)))",
+                    systemImage: "chart.bar.xaxis"
+                )
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.7))
+                Label(
+                    "P/L: \(DashboardFormatters.currency.string(from: NSDecimalNumber(decimal: trade.pnl)) ?? "—")",
+                    systemImage: trade.pnl >= 0 ? "arrowtriangle.up.fill" : "arrowtriangle.down.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(trade.pnl >= 0 ? Theme.accentGreen : Theme.accentRed)
+            }
+        }
+        .padding()
+        .background(Theme.cardBackground.cornerRadius(16))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesViewModel.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesViewModel.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SwiftUI
+
+enum TradeOutcomeFilter: String, CaseIterable, Identifiable {
+    case all
+    case winners
+    case losers
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All"
+        case .winners:
+            return "Wins"
+        case .losers:
+            return "Losses"
+        }
+    }
+}
+
+@MainActor
+final class TradesViewModel: ObservableObject {
+    @Published var trades: [TradeRecord] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var hasMorePages = true
+    @Published var symbolFilter: String = ""
+    @Published var outcomeFilter: TradeOutcomeFilter = .all
+
+    private let accessToken: String
+    private let reportingService: ReportingServiceProtocol
+    private var currentPage = 1
+    private let pageSize = 50
+
+    init(accessToken: String, reportingService: ReportingServiceProtocol) {
+        self.accessToken = accessToken
+        self.reportingService = reportingService
+    }
+
+    func loadInitial() async {
+        currentPage = 1
+        hasMorePages = true
+        trades = []
+        repeat {
+            await loadMore()
+        } while outcomeFilter != .all && filteredTrades.isEmpty && hasMorePages
+    }
+
+    func loadMore() async {
+        guard hasMorePages, !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let response = try await reportingService.fetchTrades(
+                accessToken: accessToken,
+                page: currentPage,
+                pageSize: pageSize,
+                symbol: symbolFilter.isEmpty ? nil : symbolFilter,
+                side: nil,
+                start: nil,
+                end: nil
+            )
+            currentPage += 1
+            trades.append(contentsOf: response.items)
+            hasMorePages = trades.count < response.total
+        } catch {
+            errorMessage = (error as? APIErrorResponse)?.message ?? error.localizedDescription
+            hasMorePages = false
+        }
+        isLoading = false
+    }
+
+    var filteredTrades: [TradeRecord] {
+        trades.filter { trade in
+            switch outcomeFilter {
+            case .all:
+                return true
+            case .winners:
+                return trade.pnl >= 0
+            case .losers:
+                return trade.pnl < 0
+            }
+        }
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/Models.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/Models.swift
@@ -37,3 +37,161 @@ struct UserSessionContext {
 struct APIErrorResponse: Codable, Error {
     let message: String
 }
+
+// MARK: - Reporting Models
+
+struct SystemStatus: Decodable {
+    let running: Bool
+    let uptimeSeconds: Int
+
+    enum CodingKeys: String, CodingKey {
+        case running
+        case uptimeSeconds = "uptime_seconds"
+    }
+}
+
+struct ProfitSummary: Decodable {
+    let currentBalance: Decimal
+    let totalPLAmount: Decimal
+    let totalPLPercent: Decimal
+    let winRate: Double
+
+    enum CodingKeys: String, CodingKey {
+        case currentBalance = "current_balance"
+        case totalPLAmount = "total_pl_amount"
+        case totalPLPercent = "total_pl_percent"
+        case winRate = "win_rate"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        currentBalance = try container.decodeDecimal(forKey: .currentBalance)
+        totalPLAmount = try container.decodeDecimal(forKey: .totalPLAmount)
+        totalPLPercent = try container.decodeDecimal(forKey: .totalPLPercent)
+        winRate = try container.decode(Double.self, forKey: .winRate)
+    }
+
+    init(currentBalance: Decimal, totalPLAmount: Decimal, totalPLPercent: Decimal, winRate: Double) {
+        self.currentBalance = currentBalance
+        self.totalPLAmount = totalPLAmount
+        self.totalPLPercent = totalPLPercent
+        self.winRate = winRate
+    }
+}
+
+struct BalanceSnapshot: Decodable {
+    let balance: Decimal
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        balance = try container.decodeDecimal(forKey: .balance)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case balance
+    }
+}
+
+struct EquityCurvePoint: Decodable, Identifiable {
+    let timestamp: Date
+    let equity: Decimal
+
+    var id: Date { timestamp }
+
+    init(timestamp: Date, equity: Decimal) {
+        self.timestamp = timestamp
+        self.equity = equity
+    }
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let timestampString = try container.decode(String.self)
+        let equityString = try container.decode(String.self)
+        guard let parsedTimestamp = ISO8601DateFormatter.apiFormatter.date(from: timestampString) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid timestamp: \(timestampString)")
+        }
+        guard let parsedEquity = Decimal(string: equityString) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid decimal: \(equityString)")
+        }
+        timestamp = parsedTimestamp
+        equity = parsedEquity
+    }
+}
+
+enum TradeSide: String, Decodable, CaseIterable, Identifiable {
+    case buy
+    case sell
+    case short
+    case cover
+
+    var id: String { rawValue }
+}
+
+struct TradeRecord: Decodable, Identifiable {
+    let id: Int
+    let symbol: String
+    let side: TradeSide
+    let size: Decimal
+    let pnl: Decimal
+    let timestamp: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case symbol
+        case side
+        case size
+        case pnl
+        case timestamp
+    }
+
+    init(id: Int, symbol: String, side: TradeSide, size: Decimal, pnl: Decimal, timestamp: Date) {
+        self.id = id
+        self.symbol = symbol
+        self.side = side
+        self.size = size
+        self.pnl = pnl
+        self.timestamp = timestamp
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        symbol = try container.decode(String.self, forKey: .symbol)
+        side = try container.decode(TradeSide.self, forKey: .side)
+        size = try container.decodeDecimal(forKey: .size)
+        pnl = try container.decodeDecimal(forKey: .pnl)
+        let timestampString = try container.decode(String.self, forKey: .timestamp)
+        guard let parsedTimestamp = ISO8601DateFormatter.apiFormatter.date(from: timestampString) else {
+            throw DecodingError.dataCorruptedError(forKey: .timestamp, in: container, debugDescription: "Invalid timestamp")
+        }
+        timestamp = parsedTimestamp
+    }
+}
+
+struct TradesPage: Decodable {
+    let items: [TradeRecord]
+    let page: Int
+    let pageSize: Int
+    let total: Int
+
+    enum CodingKeys: String, CodingKey {
+        case items
+        case page
+        case pageSize = "page_size"
+        case total
+    }
+}
+
+// MARK: - Decoding Helpers
+
+extension KeyedDecodingContainer {
+    func decodeDecimal(forKey key: Key) throws -> Decimal {
+        if let stringValue = try? decode(String.self, forKey: key), let decimal = Decimal(string: stringValue) {
+            return decimal
+        }
+        if let doubleValue = try? decode(Double.self, forKey: key) {
+            return Decimal(doubleValue)
+        }
+        throw DecodingError.dataCorruptedError(forKey: key, in: self, debugDescription: "Unable to decode Decimal value")
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ReportingRequests.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ReportingRequests.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum ReportingRequest: APIRequestConvertible {
+    case status(accessToken: String)
+    case profit(accessToken: String)
+    case balance(accessToken: String)
+    case equityCurve(accessToken: String, start: Date?, end: Date?, limit: Int?)
+    case trades(
+        accessToken: String,
+        page: Int,
+        pageSize: Int,
+        symbol: String?,
+        side: TradeSide?,
+        start: Date?,
+        end: Date?
+    )
+
+    var urlRequest: URLRequest {
+        get throws {
+            let base = APIEnvironment.baseURL.appending(path: "/api/v1")
+            let url: URL
+            var request: URLRequest
+            switch self {
+            case let .status(accessToken):
+                url = base.appending(path: "/status")
+                request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.addBearer(accessToken)
+            case let .profit(accessToken):
+                url = base.appending(path: "/profit")
+                request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.addBearer(accessToken)
+            case let .balance(accessToken):
+                url = base.appending(path: "/balance")
+                request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.addBearer(accessToken)
+            case let .equityCurve(accessToken, start, end, limit):
+                var components = URLComponents(url: base.appending(path: "/equity-curve"), resolvingAgainstBaseURL: false)!
+                var queryItems: [URLQueryItem] = []
+                if let start {
+                    queryItems.append(URLQueryItem(name: "start", value: ISO8601DateFormatter.apiFormatter.string(from: start)))
+                }
+                if let end {
+                    queryItems.append(URLQueryItem(name: "end", value: ISO8601DateFormatter.apiFormatter.string(from: end)))
+                }
+                if let limit {
+                    queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+                }
+                components.queryItems = queryItems.isEmpty ? nil : queryItems
+                guard let builtURL = components.url else {
+                    throw URLError(.badURL)
+                }
+                request = URLRequest(url: builtURL)
+                request.httpMethod = "GET"
+                request.addBearer(accessToken)
+            case let .trades(accessToken, page, pageSize, symbol, side, start, end):
+                var components = URLComponents(url: base.appending(path: "/trades"), resolvingAgainstBaseURL: false)!
+                var queryItems: [URLQueryItem] = [
+                    URLQueryItem(name: "page", value: String(page)),
+                    URLQueryItem(name: "page_size", value: String(pageSize))
+                ]
+                if let symbol, !symbol.isEmpty {
+                    queryItems.append(URLQueryItem(name: "symbol", value: symbol.uppercased()))
+                }
+                if let side {
+                    queryItems.append(URLQueryItem(name: "side", value: side.rawValue))
+                }
+                if let start {
+                    queryItems.append(URLQueryItem(name: "start", value: ISO8601DateFormatter.apiFormatter.string(from: start)))
+                }
+                if let end {
+                    queryItems.append(URLQueryItem(name: "end", value: ISO8601DateFormatter.apiFormatter.string(from: end)))
+                }
+                components.queryItems = queryItems
+                guard let builtURL = components.url else {
+                    throw URLError(.badURL)
+                }
+                request = URLRequest(url: builtURL)
+                request.httpMethod = "GET"
+                request.addBearer(accessToken)
+            }
+            request.addJSONHeaders()
+            return request
+        }
+    }
+}
+
+private extension URLRequest {
+    mutating func addBearer(_ token: String) {
+        addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    mutating func addJSONHeaders() {
+        addValue("application/json", forHTTPHeaderField: "Accept")
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ReportingService.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ReportingService.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+protocol ReportingServiceProtocol {
+    func fetchSystemStatus(accessToken: String) async throws -> SystemStatus
+    func fetchProfitSummary(accessToken: String) async throws -> ProfitSummary
+    func fetchCurrentBalance(accessToken: String) async throws -> Decimal
+    func fetchEquityCurve(accessToken: String, start: Date?, end: Date?, limit: Int?) async throws -> [EquityCurvePoint]
+    func fetchTrades(
+        accessToken: String,
+        page: Int,
+        pageSize: Int,
+        symbol: String?,
+        side: TradeSide?,
+        start: Date?,
+        end: Date?
+    ) async throws -> TradesPage
+}
+
+final class ReportingService: ReportingServiceProtocol {
+    private let apiClient: APIClientProtocol
+
+    init(apiClient: APIClientProtocol = APIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func fetchSystemStatus(accessToken: String) async throws -> SystemStatus {
+        try await apiClient.send(ReportingRequest.status(accessToken: accessToken), decode: SystemStatus.self)
+    }
+
+    func fetchProfitSummary(accessToken: String) async throws -> ProfitSummary {
+        try await apiClient.send(ReportingRequest.profit(accessToken: accessToken), decode: ProfitSummary.self)
+    }
+
+    func fetchCurrentBalance(accessToken: String) async throws -> Decimal {
+        let response = try await apiClient.send(ReportingRequest.balance(accessToken: accessToken), decode: BalanceSnapshot.self)
+        return response.balance
+    }
+
+    func fetchEquityCurve(accessToken: String, start: Date?, end: Date?, limit: Int?) async throws -> [EquityCurvePoint] {
+        try await apiClient.send(
+            ReportingRequest.equityCurve(accessToken: accessToken, start: start, end: end, limit: limit),
+            decode: [EquityCurvePoint].self
+        )
+    }
+
+    func fetchTrades(
+        accessToken: String,
+        page: Int,
+        pageSize: Int,
+        symbol: String?,
+        side: TradeSide?,
+        start: Date?,
+        end: Date?
+    ) async throws -> TradesPage {
+        try await apiClient.send(
+            ReportingRequest.trades(
+                accessToken: accessToken,
+                page: page,
+                pageSize: pageSize,
+                symbol: symbol,
+                side: side,
+                start: start,
+                end: end
+            ),
+            decode: TradesPage.self
+        )
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/DateFormatter+API.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/DateFormatter+API.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension ISO8601DateFormatter {
+    static let apiFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/Formatters.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/Formatters.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftUI
+
+enum DashboardFormatters {
+    static let currency: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter
+    }()
+
+    static let percent: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .percent
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter
+    }()
+}
+
+extension Decimal {
+    var doubleValue: Double {
+        NSDecimalNumber(decimal: self).doubleValue
+    }
+}
+
+extension View {
+    func dashboardCardStyle() -> some View {
+        modifier(DashboardCardModifier())
+    }
+}
+
+private struct DashboardCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Theme.cardBackground.opacity(0.95))
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+            )
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/Theme.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/Theme.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+enum Theme {
+    static let background = Color(red: 10 / 255, green: 20 / 255, blue: 45 / 255)
+    static let cardBackground = Color(red: 17 / 255, green: 32 / 255, blue: 63 / 255)
+    static let accentGreen = Color(red: 46 / 255, green: 204 / 255, blue: 113 / 255)
+    static let accentRed = Color(red: 231 / 255, green: 76 / 255, blue: 60 / 255)
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/CalendarDashboardViewModelTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/CalendarDashboardViewModelTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import AidayTradingApp
+
+@MainActor
+final class CalendarDashboardViewModelTests: XCTestCase {
+    func testGroupingResetsAtCentralMidnight() async throws {
+        let service = MockReportingService()
+        let formatter = ISO8601DateFormatter.apiFormatter
+        let trades = [
+            TradeRecord(
+                id: 1,
+                symbol: "ETHUSD",
+                side: .buy,
+                size: Decimal(string: "1.5")!,
+                pnl: Decimal(string: "150.0")!,
+                timestamp: formatter.date(from: "2024-05-15T04:30:00.000Z")!
+            ),
+            TradeRecord(
+                id: 2,
+                symbol: "ETHUSD",
+                side: .sell,
+                size: Decimal(string: "1.0")!,
+                pnl: Decimal(string: "-50.0")!,
+                timestamp: formatter.date(from: "2024-05-16T02:15:00.000Z")!
+            )
+        ]
+        service.tradesResult = .success(TradesPage(items: trades, page: 1, pageSize: 200, total: trades.count))
+
+        let viewModel = CalendarDashboardViewModel(month: formatter.date(from: "2024-05-01T00:00:00.000Z")!, accessToken: "token", reportingService: service)
+        await viewModel.loadMonth()
+
+        let positiveCell = viewModel.dayCells.first { cell in
+            guard let date = cell.date else { return false }
+            return Calendar(identifier: .gregorian).dateComponents([.day], from: date).day == 15
+        }
+        let negativeCell = viewModel.dayCells.first { cell in
+            guard let date = cell.date else { return false }
+            return Calendar(identifier: .gregorian).dateComponents([.day], from: date).day == 16
+        }
+
+        XCTAssertEqual(positiveCell?.pnl, Decimal(string: "150.0")!)
+        XCTAssertEqual(negativeCell?.pnl, Decimal(string: "-50.0")!)
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/DashboardSnapshotTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/DashboardSnapshotTests.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import XCTest
+@testable import AidayTradingApp
+
+#if canImport(SwiftUI)
+
+@MainActor
+final class DashboardSnapshotTests: XCTestCase {
+    private let context = UserSessionContext(
+        profile: UserProfile(
+            id: UUID(),
+            username: "snapshot",
+            email: "snapshot@example.com",
+            role: .viewer,
+            approvalStatus: .approved
+        ),
+        tokens: AuthTokens(accessToken: "token", refreshToken: "refresh", accessTokenExpiry: .distantFuture)
+    )
+
+    func testHomeDashboardSnapshotProducesImage() async throws {
+        let service = MockReportingService()
+        service.statusResult = .success(SystemStatus(running: true, uptimeSeconds: 7200))
+        service.profitResult = .success(
+            ProfitSummary(
+                currentBalance: Decimal(string: "10500")!,
+                totalPLAmount: Decimal(string: "500")!,
+                totalPLPercent: Decimal(string: "5.0")!,
+                winRate: 0.58
+            )
+        )
+        service.balanceResult = .success(Decimal(string: "10500")!)
+        service.equityResult = .success([
+            EquityCurvePoint(timestamp: Date().addingTimeInterval(-3600 * 3), equity: Decimal(string: "9800")!),
+            EquityCurvePoint(timestamp: Date().addingTimeInterval(-3600 * 2), equity: Decimal(string: "10050")!),
+            EquityCurvePoint(timestamp: Date().addingTimeInterval(-3600), equity: Decimal(string: "10200")!),
+            EquityCurvePoint(timestamp: Date(), equity: Decimal(string: "10500")!)
+        ])
+
+        let viewModel = HomeDashboardViewModel(accessToken: context.tokens.accessToken, reportingService: service)
+        await viewModel.loadData()
+
+        let view = HomeView(context: context, viewModel: viewModel)
+        let renderer = ImageRenderer(content: view.frame(width: 375, height: 812))
+
+        #if canImport(UIKit)
+        XCTAssertNotNil(renderer.uiImage)
+        #elseif canImport(AppKit)
+        XCTAssertNotNil(renderer.nsImage)
+        #else
+        throw XCTSkip("Snapshot rendering not supported on this platform")
+        #endif
+    }
+
+    func testCalendarSnapshotProducesImage() async throws {
+        let service = MockReportingService()
+        let formatter = ISO8601DateFormatter.apiFormatter
+        let trades = [
+            TradeRecord(
+                id: 1,
+                symbol: "BTCUSD",
+                side: .buy,
+                size: Decimal(string: "0.5")!,
+                pnl: Decimal(string: "200.0")!,
+                timestamp: formatter.date(from: "2024-05-10T15:30:00.000Z")!
+            ),
+            TradeRecord(
+                id: 2,
+                symbol: "BTCUSD",
+                side: .sell,
+                size: Decimal(string: "0.25")!,
+                pnl: Decimal(string: "-80.0")!,
+                timestamp: formatter.date(from: "2024-05-11T18:45:00.000Z")!
+            )
+        ]
+        service.tradesResult = .success(TradesPage(items: trades, page: 1, pageSize: 200, total: trades.count))
+
+        let viewModel = CalendarDashboardViewModel(month: formatter.date(from: "2024-05-01T00:00:00.000Z")!, accessToken: context.tokens.accessToken, reportingService: service)
+        await viewModel.loadMonth()
+
+        let view = CalendarView(context: context, viewModel: viewModel)
+        let renderer = ImageRenderer(content: view.frame(width: 375, height: 700))
+
+        #if canImport(UIKit)
+        XCTAssertNotNil(renderer.uiImage)
+        #elseif canImport(AppKit)
+        XCTAssertNotNil(renderer.nsImage)
+        #else
+        throw XCTSkip("Snapshot rendering not supported on this platform")
+        #endif
+    }
+}
+#endif

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/HomeDashboardViewModelTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/HomeDashboardViewModelTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AidayTradingApp
+
+@MainActor
+final class HomeDashboardViewModelTests: XCTestCase {
+    private let tokens = AuthTokens(accessToken: "token", refreshToken: "refresh", accessTokenExpiry: .distantFuture)
+
+    func testLoadDataPopulatesMetricsAndFallbacksBalance() async {
+        let service = MockReportingService()
+        service.statusResult = .success(SystemStatus(running: true, uptimeSeconds: 300))
+        let profit = ProfitSummary(
+            currentBalance: Decimal(string: "10000")!,
+            totalPLAmount: Decimal(string: "250")!,
+            totalPLPercent: Decimal(string: "2.5")!,
+            winRate: 0.55
+        )
+        service.profitResult = .success(profit)
+        service.balanceResult = .failure(MockError.notConfigured)
+        service.equityResult = .success([
+            EquityCurvePoint(timestamp: Date(), equity: Decimal(string: "10000")!)
+        ])
+
+        let viewModel = HomeDashboardViewModel(accessToken: tokens.accessToken, reportingService: service)
+        await viewModel.loadData()
+
+        XCTAssertEqual(viewModel.profitSummary?.currentBalance, profit.currentBalance)
+        XCTAssertEqual(viewModel.balance, profit.currentBalance)
+        XCTAssertEqual(viewModel.systemStatus?.running, true)
+        XCTAssertFalse(viewModel.equitySeries.isEmpty)
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
@@ -77,3 +77,39 @@ enum MockError: Error {
     case notConfigured
     case biometricFailed
 }
+
+final class MockReportingService: ReportingServiceProtocol {
+    var statusResult: Result<SystemStatus, Error> = .failure(MockError.notConfigured)
+    var profitResult: Result<ProfitSummary, Error> = .failure(MockError.notConfigured)
+    var balanceResult: Result<Decimal, Error> = .failure(MockError.notConfigured)
+    var equityResult: Result<[EquityCurvePoint], Error> = .failure(MockError.notConfigured)
+    var tradesResult: Result<TradesPage, Error> = .failure(MockError.notConfigured)
+
+    func fetchSystemStatus(accessToken: String) async throws -> SystemStatus {
+        try statusResult.get()
+    }
+
+    func fetchProfitSummary(accessToken: String) async throws -> ProfitSummary {
+        try profitResult.get()
+    }
+
+    func fetchCurrentBalance(accessToken: String) async throws -> Decimal {
+        try balanceResult.get()
+    }
+
+    func fetchEquityCurve(accessToken: String, start: Date?, end: Date?, limit: Int?) async throws -> [EquityCurvePoint] {
+        try equityResult.get()
+    }
+
+    func fetchTrades(
+        accessToken: String,
+        page: Int,
+        pageSize: Int,
+        symbol: String?,
+        side: TradeSide?,
+        start: Date?,
+        end: Date?
+    ) async throws -> TradesPage {
+        try tradesResult.get()
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/ReportingModelsTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/ReportingModelsTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import AidayTradingApp
+
+final class ReportingModelsTests: XCTestCase {
+    func testProfitSummaryDecoding() throws {
+        let json = """
+        {
+            "current_balance": "10500.50",
+            "total_pl_amount": "500.50",
+            "total_pl_percent": "5.005",
+            "win_rate": 0.62
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let summary = try decoder.decode(ProfitSummary.self, from: json)
+        XCTAssertEqual(summary.currentBalance, Decimal(string: "10500.50")!)
+        XCTAssertEqual(summary.totalPLAmount, Decimal(string: "500.50")!)
+        XCTAssertEqual(summary.totalPLPercent, Decimal(string: "5.005")!)
+        XCTAssertEqual(summary.winRate, 0.62, accuracy: 0.0001)
+    }
+
+    func testEquityCurveDecoding() throws {
+        let json = """
+        [["2024-05-01T00:00:00.000Z", "10000.0"], ["2024-05-01T01:00:00.000Z", "10125.75"]]
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let points = try decoder.decode([EquityCurvePoint].self, from: json)
+        XCTAssertEqual(points.count, 2)
+        XCTAssertEqual(points[0].equity, Decimal(string: "10000.0")!)
+        XCTAssertEqual(points[1].timestamp, ISO8601DateFormatter.apiFormatter.date(from: "2024-05-01T01:00:00.000Z"))
+    }
+
+    func testTradeRecordDecoding() throws {
+        let json = """
+        {
+            "items": [
+                {
+                    "id": 1,
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "size": "10",
+                    "pnl": "15.5",
+                    "timestamp": "2024-05-01T14:30:00.000Z"
+                }
+            ],
+            "page": 1,
+            "page_size": 50,
+            "total": 1
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let page = try decoder.decode(TradesPage.self, from: json)
+        XCTAssertEqual(page.items.first?.symbol, "AAPL")
+        XCTAssertEqual(page.items.first?.side, .buy)
+        XCTAssertEqual(page.total, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder Home, Calendar, and Trades tabs with production SwiftUI dashboards driven by reporting data
- add reporting service and supporting models/utilities to call the status, profit, balance, equity, and trades endpoints
- implement unit, integration, and snapshot tests covering API decoding, calendar aggregation, and dashboard rendering

## Testing
- Not run (platform-specific project)

------
https://chatgpt.com/codex/tasks/task_e_68d745658cb4832f99b56f9c4dd1bc75