### PR TITLE
Add realtime WebSocket layer and push notification support

### DIFF
--- a/ios/AidayTradingApp/README.md
+++ b/ios/AidayTradingApp/README.md
@@ -12,6 +12,9 @@ This SwiftUI application provides the secure mobile entry point for the AidayTra
 - Sensitive screen protections including Face ID / Touch ID gating, idle-timeout logout, and screen capture monitoring.
 - Unit and integration tests covering authentication, token handling, role detection, and approval workflow.
 - Viewer dashboards with equity charts, calendar PnL heatmap, and a paginated trade ledger consuming `/api/v1` reporting endpoints.
+- Real-time dashboards sourced from authenticated WebSocket feeds with automatic reconnect and disconnect banners.
+- Push notifications delivered via Firebase Cloud Messaging, including deep linking into the correct tab when tapped.
+- Local notification fallback that warns the operator if the realtime feed stalls.
 
 ## Project structure
 
@@ -60,6 +63,11 @@ The app expects the backend (Prompt A) to expose HTTPS endpoints:
 - `POST /auth/login`  → `{ "tokens": { ... }, "user": { ... } }`
 - `POST /auth/refresh`
 - `GET /users/me`
+- `GET /ws/status` (authenticated WebSocket channel publishing `{ "running": bool, "uptime_seconds": int }` updates)
+- `GET /ws/equity` (authenticated WebSocket channel emitting equity curve points as `[timestamp, equity]` arrays at 10 minute cadence)
+- `GET /ws/trades` (authenticated WebSocket channel streaming trade executions in real-time)
+- `POST /api/v1/notifications/devices` expecting `{ "token": string, "platform": "ios", "timezone": string }`
+- Remote notification payloads should include a `target` field (`home`, `trades`, `calendar`, or `admin`) so the app can deep link when the user taps alerts. Schedule balance/PnL recaps at 8am, 2pm, 8pm, and 2am Central Time and send bot state changes via FCM topics or user-specific tokens.
 
 Responses should encode dates using ISO-8601 to match the bundled `JSONDecoder` configuration.
 
@@ -91,10 +99,25 @@ swiftlint
 xcodebuild test
 ```
 
+Automated tests use a mocked WebSocket server to validate reconnect logic, push-token registration, and notification routing behaviour. You can execute the tests via:
+
+```bash
+cd ios/AidayTradingApp
+xcodegen generate
+xcodebuild \
+  -scheme AidayTradingApp \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  test
+```
+
+The mocked realtime layer lives in `Tests/AidayTradingAppTests/RealtimeServiceTests.swift`.
+
 ## Environment configuration
 
 - Configure environment variables for any secrets (e.g., Brevo API key) at the backend level. The iOS client never stores or hardcodes sensitive values.
 - Update `APIEnvironment.baseURL` to point to your deployment if it changes.
+- Add your Firebase `GoogleService-Info.plist` under `Sources/AidayTradingApp/Application/` before building. The app registers for push notifications via Firebase Messaging and expects APNs credentials configured in the Firebase console.
+- Enable the `Push Notifications` capability in your Apple Developer account and ensure the `remote-notification` background mode entitlement is granted.
 
 ## Next steps
 
@@ -102,3 +125,4 @@ xcodebuild test
 - Extend admin tooling with approval actions (approve/reject users, manage risk limits).
 - Add push notification support for approval status changes.
 - Expand dashboard analytics with additional strategy drill-downs.
+- Add per-strategy real-time feeds and refine notification targeting for complex user roles.

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Application/AidayTradingApp.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Application/AidayTradingApp.swift
@@ -2,15 +2,25 @@ import SwiftUI
 
 @main
 struct AidayTradingApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var session = SessionStore()
+    @StateObject private var notificationController = NotificationController()
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(session)
+                .environmentObject(notificationController)
                 .onChange(of: scenePhase) { _, newPhase in
                     session.handleScenePhaseChange(newPhase)
+                }
+                .onAppear {
+                    appDelegate.notificationController = notificationController
+                    notificationController.updateSessionState(session.state)
+                }
+                .onChange(of: session.state) { _, newState in
+                    notificationController.updateSessionState(newState)
                 }
         }
     }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Application/Info.plist
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Application/Info.plist
@@ -36,5 +36,11 @@
 <key>NSExceptionDomains</key>
 <dict/>
 </dict>
+<key>UIBackgroundModes</key>
+<array>
+    <string>remote-notification</string>
+</array>
+<key>FirebaseAppDelegateProxyEnabled</key>
+<false/>
 </dict>
 </plist>

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Application/NotificationController.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Application/NotificationController.swift
@@ -1,0 +1,99 @@
+import Foundation
+import SwiftUI
+import UIKit
+import UserNotifications
+
+@MainActor
+final class NotificationController: ObservableObject {
+    @Published private(set) var pendingTab: MainTabView.Tab?
+
+    private let pushService: PushNotificationRegistering
+    private let localScheduler: LocalNotificationScheduling
+    private var currentSession: UserSessionContext?
+    private var cachedFCMToken: String?
+    private var hasRequestedAuthorization = false
+    private var lastRegisteredToken: String?
+
+    init(
+        pushService: PushNotificationRegistering = PushNotificationService(),
+        localScheduler: LocalNotificationScheduling = LocalNotificationScheduler()
+    ) {
+        self.pushService = pushService
+        self.localScheduler = localScheduler
+    }
+
+    func updateSessionState(_ state: SessionStore.SessionState) {
+        switch state {
+        case .authenticated(let context):
+            currentSession = context
+            requestNotificationAuthorizationIfNeeded()
+            Task {
+                await registerIfPossible()
+            }
+        default:
+            currentSession = nil
+            cachedFCMToken = nil
+            lastRegisteredToken = nil
+        }
+    }
+
+    func registerFCMToken(_ token: String) {
+        cachedFCMToken = token
+        Task {
+            await registerIfPossible()
+        }
+    }
+
+    func handleRemoteNotification(userInfo: [AnyHashable: Any]) {
+        guard let target = userInfo["target"] as? String else { return }
+        switch target.lowercased() {
+        case "trades":
+            pendingTab = .trades
+        case "calendar":
+            pendingTab = .calendar
+        case "admin":
+            pendingTab = .admin
+        default:
+            pendingTab = .home
+        }
+    }
+
+    func consumePendingTab() -> MainTabView.Tab? {
+        defer { pendingTab = nil }
+        return pendingTab
+    }
+
+    func scheduleRealtimeStallNotification() {
+        Task {
+            await localScheduler.scheduleRealtimeStallNotification()
+        }
+    }
+
+    func cancelRealtimeStallNotification() {
+        localScheduler.cancelRealtimeStallNotification()
+    }
+
+    private func requestNotificationAuthorizationIfNeeded() {
+        guard !hasRequestedAuthorization else { return }
+        hasRequestedAuthorization = true
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+        }
+    }
+
+    private func registerIfPossible() async {
+        guard let context = currentSession, let token = cachedFCMToken else { return }
+        guard token != lastRegisteredToken else { return }
+        do {
+            try await pushService.register(deviceToken: token, accessToken: context.tokens.accessToken)
+            lastRegisteredToken = token
+        } catch {
+            // Surface the error via console for diagnostics but avoid alerting end users repeatedly.
+            NSLog("Failed to register push token: \(error.localizedDescription)")
+        }
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/RootView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/RootView.swift
@@ -30,4 +30,5 @@ struct RootView: View {
 #Preview {
     RootView()
         .environmentObject(SessionStore(previewState: .loggedOut))
+        .environmentObject(NotificationController())
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/HomeView.swift
@@ -37,8 +37,16 @@ struct HomeView: View {
                 viewModel.stop()
             }
             .overlay(alignment: .bottom) {
-                if let error = viewModel.errorMessage {
-                    errorBanner(message: error)
+                if viewModel.realtimeWarningMessage != nil || viewModel.errorMessage != nil {
+                    VStack(spacing: 8) {
+                        if let realtimeWarning = viewModel.realtimeWarningMessage {
+                            errorBanner(message: realtimeWarning)
+                        }
+                        if let error = viewModel.errorMessage {
+                            errorBanner(message: error)
+                        }
+                    }
+                    .padding(.bottom, 16)
                 }
             }
         }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
@@ -4,6 +4,7 @@ struct MainTabView: View {
     let context: UserSessionContext
     private let reportingService: ReportingServiceProtocol
     @EnvironmentObject private var session: SessionStore
+    @EnvironmentObject private var notificationController: NotificationController
 
     enum Tab: Hashable {
         case home
@@ -55,6 +56,11 @@ struct MainTabView: View {
         .onAppear {
             session.registerInteraction()
         }
+        .onChange(of: notificationController.pendingTab) { _, newValue in
+            guard let tab = newValue else { return }
+            selection = tab
+            _ = notificationController.consumePendingTab()
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Logout") {
@@ -76,4 +82,5 @@ struct MainTabView: View {
     let tokens = AuthTokens(accessToken: "token", refreshToken: "refresh", accessTokenExpiry: .distantFuture)
     return MainTabView(context: UserSessionContext(profile: profile, tokens: tokens))
         .environmentObject(SessionStore(previewState: .authenticated(UserSessionContext(profile: profile, tokens: tokens))))
+        .environmentObject(NotificationController())
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/TradesView.swift
@@ -44,9 +44,20 @@ struct TradesView: View {
             .onChange(of: viewModel.outcomeFilter) { _, _ in
                 Task { await viewModel.loadInitial() }
             }
+            .onDisappear {
+                viewModel.stop()
+            }
             .overlay(alignment: .bottom) {
-                if let error = viewModel.errorMessage {
-                    errorBanner(message: error)
+                if viewModel.realtimeWarningMessage != nil || viewModel.errorMessage != nil {
+                    VStack(spacing: 8) {
+                        if let realtimeWarning = viewModel.realtimeWarningMessage {
+                            errorBanner(message: realtimeWarning)
+                        }
+                        if let error = viewModel.errorMessage {
+                            errorBanner(message: error)
+                        }
+                    }
+                    .padding(.bottom, 16)
                 }
             }
         }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/NotificationRequests.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/NotificationRequests.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum NotificationRequest: APIRequestConvertible {
+    case register(deviceToken: String, platform: String, timezone: String, accessToken: String)
+
+    var urlRequest: URLRequest {
+        get throws {
+            switch self {
+            case let .register(deviceToken, platform, timezone, accessToken):
+                var request = URLRequest(url: APIEnvironment.baseURL.appending(path: "/api/v1/notifications/devices"))
+                request.httpMethod = "POST"
+                request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+                request.addValue("application/json", forHTTPHeaderField: "Accept")
+                request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+                let payload: [String: String] = [
+                    "token": deviceToken,
+                    "platform": platform,
+                    "timezone": timezone
+                ]
+                request.httpBody = try JSONEncoder().encode(payload)
+                return request
+            }
+        }
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/NotificationService.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/NotificationService.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+protocol PushNotificationRegistering {
+    func register(deviceToken: String, accessToken: String) async throws
+}
+
+struct PushNotificationService: PushNotificationRegistering {
+    private let apiClient: APIClientProtocol
+
+    init(apiClient: APIClientProtocol = APIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func register(deviceToken: String, accessToken: String) async throws {
+        let timezone = TimeZone.current.identifier
+        try await apiClient.send(NotificationRequest.register(deviceToken: deviceToken, platform: "ios", timezone: timezone, accessToken: accessToken))
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/RealtimeService.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/RealtimeService.swift
@@ -1,0 +1,250 @@
+import Foundation
+import os
+
+protocol RealtimeServiceDelegate: AnyObject {
+    func realtimeServiceDidConnect(_ service: RealtimeServiceProtocol)
+    func realtimeService(_ service: RealtimeServiceProtocol, didDisconnectWith error: Error?)
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveStatus status: SystemStatus)
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveEquityPoint point: EquityCurvePoint)
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveTrade trade: TradeRecord)
+    func realtimeServiceDidDetectStall(_ service: RealtimeServiceProtocol)
+}
+
+protocol RealtimeServiceProtocol: AnyObject {
+    var delegate: RealtimeServiceDelegate? { get set }
+    func connect(accessToken: String)
+    func disconnect()
+}
+
+protocol WebSocketClient: AnyObject {
+    var delegate: WebSocketClientDelegate? { get set }
+    func connect()
+    func disconnect(with code: URLSessionWebSocketTask.CloseCode)
+}
+
+enum WebSocketChannel: String {
+    case status
+    case equity
+    case trades
+}
+
+protocol WebSocketClientDelegate: AnyObject {
+    func webSocketClientDidOpen(_ client: WebSocketClient, channel: WebSocketChannel)
+    func webSocketClient(_ client: WebSocketClient, channel: WebSocketChannel, didReceive data: Data)
+    func webSocketClient(_ client: WebSocketClient, channel: WebSocketChannel, didFailWith error: Error)
+}
+
+protocol WebSocketClientFactory {
+    func makeClient(url: URL, headers: [String: String], channel: WebSocketChannel, delegate: WebSocketClientDelegate?) -> WebSocketClient
+}
+
+final class URLSessionWebSocketClient: NSObject, WebSocketClient {
+    private let task: URLSessionWebSocketTask
+    private let channel: WebSocketChannel
+    weak var delegate: WebSocketClientDelegate?
+
+    init(session: URLSession, request: URLRequest, channel: WebSocketChannel, delegate: WebSocketClientDelegate?) {
+        self.task = session.webSocketTask(with: request)
+        self.channel = channel
+        self.delegate = delegate
+        super.init()
+    }
+
+    func connect() {
+        task.resume()
+        delegate?.webSocketClientDidOpen(self, channel: channel)
+        listen()
+    }
+
+    private func listen() {
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case let .success(message):
+                switch message {
+                case let .data(data):
+                    delegate?.webSocketClient(self, channel: channel, didReceive: data)
+                case let .string(string):
+                    if let data = string.data(using: .utf8) {
+                        delegate?.webSocketClient(self, channel: channel, didReceive: data)
+                    }
+                @unknown default:
+                    break
+                }
+                self.listen()
+            case let .failure(error):
+                delegate?.webSocketClient(self, channel: channel, didFailWith: error)
+            }
+        }
+    }
+
+    func disconnect(with code: URLSessionWebSocketTask.CloseCode) {
+        task.cancel(with: code, reason: nil)
+    }
+}
+
+struct URLSessionWebSocketClientFactory: WebSocketClientFactory {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func makeClient(url: URL, headers: [String: String], channel: WebSocketChannel, delegate: WebSocketClientDelegate?) -> WebSocketClient {
+        var request = URLRequest(url: url)
+        headers.forEach { key, value in
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+        return URLSessionWebSocketClient(session: session, request: request, channel: channel, delegate: delegate)
+    }
+}
+
+final class RealtimeService: NSObject, RealtimeServiceProtocol {
+    weak var delegate: RealtimeServiceDelegate?
+
+    private struct ChannelState {
+        var client: WebSocketClient?
+        var reconnectDelay: TimeInterval
+        var isConnected = false
+    }
+
+    private var channels: [WebSocketChannel: ChannelState] = [:]
+    private let factory: WebSocketClientFactory
+    private var accessToken: String?
+    private let decoder: JSONDecoder
+    private let log = Logger(subsystem: "com.aidaytrading.app", category: "RealtimeService")
+    private var stallTask: Task<Void, Never>?
+    private let stallInterval: TimeInterval
+    private let initialReconnectDelay: TimeInterval
+    private var lastEquityUpdate: Date?
+
+    init(
+        factory: WebSocketClientFactory = URLSessionWebSocketClientFactory(),
+        stallInterval: TimeInterval = 300,
+        initialReconnectDelay: TimeInterval = 1
+    ) {
+        self.factory = factory
+        self.stallInterval = stallInterval
+        self.initialReconnectDelay = initialReconnectDelay
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        super.init()
+    }
+
+    func connect(accessToken: String) {
+        self.accessToken = accessToken
+        open(channel: .status, path: "/ws/status")
+        open(channel: .equity, path: "/ws/equity")
+        open(channel: .trades, path: "/ws/trades")
+        resetStallMonitor()
+    }
+
+    func disconnect() {
+        stallTask?.cancel()
+        stallTask = nil
+        channels.forEach { _, state in
+            state.client?.disconnect(with: .goingAway)
+        }
+        channels.removeAll()
+        accessToken = nil
+        lastEquityUpdate = nil
+    }
+
+    private func open(channel: WebSocketChannel, path: String) {
+        guard let token = accessToken else { return }
+        let url = APIEnvironment.baseURL.appending(path: path)
+        let headers = [
+            "Authorization": "Bearer \(token)",
+            "Accept": "application/json"
+        ]
+        var state = channels[channel] ?? ChannelState(client: nil, reconnectDelay: initialReconnectDelay, isConnected: false)
+        let client = factory.makeClient(url: url, headers: headers, channel: channel, delegate: self)
+        state.client = client
+        state.isConnected = false
+        state.reconnectDelay = initialReconnectDelay
+        channels[channel] = state
+        client.connect()
+    }
+
+    private func scheduleReconnect(for channel: WebSocketChannel) {
+        guard var state = channels[channel] else { return }
+        state.isConnected = false
+        channels[channel] = state
+        notifyDisconnected()
+        stallTask?.cancel()
+        resetStallMonitor()
+        let delay = min(state.reconnectDelay, 60)
+        log.debug("Scheduling reconnect for \(channel.rawValue, privacy: .public) in \(delay, privacy: .public)s")
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            await MainActor.run {
+                guard let self else { return }
+                var updatedState = self.channels[channel] ?? ChannelState(client: nil, reconnectDelay: self.initialReconnectDelay, isConnected: false)
+                updatedState.reconnectDelay = min(delay * 2, 60)
+                self.channels[channel] = updatedState
+                self.open(channel: channel, path: "/ws/\(channel.rawValue)")
+            }
+        }
+    }
+
+    private func notifyConnectedIfNeeded() {
+        if channels.values.allSatisfy({ $0.isConnected }) {
+            delegate?.realtimeServiceDidConnect(self)
+        }
+    }
+
+    private func notifyDisconnected() {
+        delegate?.realtimeService(self, didDisconnectWith: nil)
+    }
+
+    private func resetStallMonitor() {
+        stallTask?.cancel()
+        stallTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(stallInterval * 1_000_000_000))
+            await MainActor.run {
+                self.delegate?.realtimeServiceDidDetectStall(self)
+            }
+        }
+    }
+
+    private func handleEquityMessage(_ data: Data) {
+        guard let point = try? decoder.decode(EquityCurvePoint.self, from: data) else { return }
+        if let lastEquityUpdate, point.timestamp.timeIntervalSince(lastEquityUpdate) < 600 {
+            return
+        }
+        lastEquityUpdate = point.timestamp
+        delegate?.realtimeService(self, didReceiveEquityPoint: point)
+    }
+}
+
+extension RealtimeService: WebSocketClientDelegate {
+    func webSocketClientDidOpen(_ client: WebSocketClient, channel: WebSocketChannel) {
+        guard var state = channels[channel] else { return }
+        state.isConnected = true
+        state.reconnectDelay = initialReconnectDelay
+        channels[channel] = state
+        notifyConnectedIfNeeded()
+    }
+
+    func webSocketClient(_ client: WebSocketClient, channel: WebSocketChannel, didReceive data: Data) {
+        resetStallMonitor()
+        switch channel {
+        case .status:
+            if let status = try? decoder.decode(SystemStatus.self, from: data) {
+                delegate?.realtimeService(self, didReceiveStatus: status)
+            }
+        case .equity:
+            handleEquityMessage(data)
+        case .trades:
+            if let trade = try? decoder.decode(TradeRecord.self, from: data) {
+                delegate?.realtimeService(self, didReceiveTrade: trade)
+            }
+        }
+    }
+
+    func webSocketClient(_ client: WebSocketClient, channel: WebSocketChannel, didFailWith error: Error) {
+        log.error("WebSocket channel \(channel.rawValue, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+        scheduleReconnect(for: channel)
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/LocalNotificationScheduler.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/LocalNotificationScheduler.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UserNotifications
+
+protocol LocalNotificationScheduling {
+    func scheduleRealtimeStallNotification() async
+    func cancelRealtimeStallNotification()
+}
+
+struct LocalNotificationScheduler: LocalNotificationScheduling {
+    private let notificationCenter: UNUserNotificationCenter
+    private let identifier = "com.aidaytrading.notifications.realtime-stall"
+
+    init(notificationCenter: UNUserNotificationCenter = .current()) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func scheduleRealtimeStallNotification() async {
+        let settings = await notificationCenter.notificationSettings()
+        if settings.authorizationStatus != .authorized {
+            _ = try? await notificationCenter.requestAuthorization(options: [.alert, .badge, .sound])
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Realtime data paused"
+        content.body = "We haven't received new trading data recently. Reopen the app to refresh."
+        content.sound = .default
+        content.userInfo = ["target": "home"]
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        try? await notificationCenter.add(request)
+    }
+
+    func cancelRealtimeStallNotification() {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier])
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/DashboardSnapshotTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/DashboardSnapshotTests.swift
@@ -36,7 +36,12 @@ final class DashboardSnapshotTests: XCTestCase {
             EquityCurvePoint(timestamp: Date(), equity: Decimal(string: "10500")!)
         ])
 
-        let viewModel = HomeDashboardViewModel(accessToken: context.tokens.accessToken, reportingService: service)
+        let viewModel = HomeDashboardViewModel(
+            accessToken: context.tokens.accessToken,
+            reportingService: service,
+            realtimeService: MockRealtimeService(),
+            notificationScheduler: MockLocalNotificationScheduler()
+        )
         await viewModel.loadData()
 
         let view = HomeView(context: context, viewModel: viewModel)

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/HomeDashboardViewModelTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/HomeDashboardViewModelTests.swift
@@ -20,7 +20,12 @@ final class HomeDashboardViewModelTests: XCTestCase {
             EquityCurvePoint(timestamp: Date(), equity: Decimal(string: "10000")!)
         ])
 
-        let viewModel = HomeDashboardViewModel(accessToken: tokens.accessToken, reportingService: service)
+        let viewModel = HomeDashboardViewModel(
+            accessToken: tokens.accessToken,
+            reportingService: service,
+            realtimeService: MockRealtimeService(),
+            notificationScheduler: MockLocalNotificationScheduler()
+        )
         await viewModel.loadData()
 
         XCTAssertEqual(viewModel.profitSummary?.currentBalance, profit.currentBalance)

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
@@ -78,6 +78,43 @@ enum MockError: Error {
     case biometricFailed
 }
 
+final class MockLocalNotificationScheduler: LocalNotificationScheduling {
+    private(set) var scheduleCallCount = 0
+    private(set) var cancelCallCount = 0
+
+    func scheduleRealtimeStallNotification() async {
+        scheduleCallCount += 1
+    }
+
+    func cancelRealtimeStallNotification() {
+        cancelCallCount += 1
+    }
+}
+
+final class MockPushNotificationService: PushNotificationRegistering {
+    private(set) var lastToken: String?
+    private(set) var registerCallCount = 0
+
+    func register(deviceToken: String, accessToken: String) async throws {
+        lastToken = deviceToken
+        registerCallCount += 1
+    }
+}
+
+final class MockRealtimeService: RealtimeServiceProtocol {
+    weak var delegate: RealtimeServiceDelegate?
+    private(set) var connectCallCount = 0
+    private(set) var disconnectCallCount = 0
+
+    func connect(accessToken: String) {
+        connectCallCount += 1
+    }
+
+    func disconnect() {
+        disconnectCallCount += 1
+    }
+}
+
 final class MockReportingService: ReportingServiceProtocol {
     var statusResult: Result<SystemStatus, Error> = .failure(MockError.notConfigured)
     var profitResult: Result<ProfitSummary, Error> = .failure(MockError.notConfigured)

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/NotificationControllerTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/NotificationControllerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import AidayTradingApp
+
+final class NotificationControllerTests: XCTestCase {
+    func testRegistersPushTokenWhenSessionAvailable() async {
+        let pushService = MockPushNotificationService()
+        let controller = NotificationController(pushService: pushService, localScheduler: MockLocalNotificationScheduler())
+        let profile = UserProfile(
+            id: UUID(),
+            username: "Trader",
+            email: "trader@example.com",
+            role: .viewer,
+            approvalStatus: .approved
+        )
+        let tokens = AuthTokens(accessToken: "access", refreshToken: "refresh", accessTokenExpiry: Date().addingTimeInterval(3600))
+        controller.updateSessionState(.authenticated(UserSessionContext(profile: profile, tokens: tokens)))
+
+        controller.registerFCMToken("abc123")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(pushService.lastToken, "abc123")
+        XCTAssertEqual(pushService.registerCallCount, 1)
+
+        controller.registerFCMToken("abc123")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(pushService.registerCallCount, 1, "Duplicate tokens should not trigger another registration")
+    }
+
+    func testRoutesNotificationsToCorrectTab() {
+        let controller = NotificationController(pushService: MockPushNotificationService(), localScheduler: MockLocalNotificationScheduler())
+        controller.handleRemoteNotification(userInfo: ["target": "trades"])
+        XCTAssertEqual(controller.consumePendingTab(), .trades)
+
+        controller.handleRemoteNotification(userInfo: ["target": "calendar"])
+        XCTAssertEqual(controller.consumePendingTab(), .calendar)
+
+        controller.handleRemoteNotification(userInfo: ["target": "unknown"])
+        XCTAssertEqual(controller.consumePendingTab(), .home)
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/RealtimeServiceTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/RealtimeServiceTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import AidayTradingApp
+
+final class RealtimeServiceTests: XCTestCase {
+    func testReconnectsAfterFailure() async throws {
+        let statusMessage = try XCTUnwrap("{" +
+            "\"running\":true,\"uptime_seconds\":120" +
+            "}".data(using: .utf8))
+        let equityMessage = try JSONSerialization.data(withJSONObject: [
+            ISO8601DateFormatter.apiFormatter.string(from: Date()),
+            "1000.00"
+        ])
+        let tradeMessage = try JSONSerialization.data(withJSONObject: [
+            "id": 1,
+            "symbol": "BTCUSD",
+            "side": "buy",
+            "size": "1.0",
+            "pnl": "50.00",
+            "timestamp": ISO8601DateFormatter.apiFormatter.string(from: Date())
+        ])
+
+        let factory = MockWebSocketClientFactory()
+        factory.enqueue(
+            client: MockWebSocketClient(channel: .status, events: [.message(statusMessage), .failure(MockError.notConfigured)]),
+            for: .status
+        )
+        factory.enqueue(
+            client: MockWebSocketClient(channel: .status, events: [.message(statusMessage)]),
+            for: .status
+        )
+        factory.enqueue(client: MockWebSocketClient(channel: .equity, events: [.message(equityMessage)]), for: .equity)
+        factory.enqueue(client: MockWebSocketClient(channel: .equity, events: [.message(equityMessage)]), for: .equity)
+        factory.enqueue(client: MockWebSocketClient(channel: .trades, events: [.message(tradeMessage)]), for: .trades)
+        factory.enqueue(client: MockWebSocketClient(channel: .trades, events: [.message(tradeMessage)]), for: .trades)
+
+        let service = RealtimeService(factory: factory, stallInterval: 0.5, initialReconnectDelay: 0.05)
+        let delegate = CapturingRealtimeDelegate()
+        service.delegate = delegate
+
+        service.connect(accessToken: "token")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertGreaterThanOrEqual(delegate.connectedCount, 1)
+
+        try await Task.sleep(nanoseconds: 700_000_000)
+        XCTAssertTrue(delegate.didReceiveDisconnect)
+        XCTAssertGreaterThanOrEqual(delegate.connectedCount, 2)
+    }
+}
+
+private final class CapturingRealtimeDelegate: RealtimeServiceDelegate {
+    private(set) var connectedCount = 0
+    private(set) var didReceiveDisconnect = false
+
+    func realtimeServiceDidConnect(_ service: RealtimeServiceProtocol) {
+        connectedCount += 1
+    }
+
+    func realtimeService(_ service: RealtimeServiceProtocol, didDisconnectWith error: Error?) {
+        didReceiveDisconnect = true
+    }
+
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveStatus status: SystemStatus) {}
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveEquityPoint point: EquityCurvePoint) {}
+    func realtimeService(_ service: RealtimeServiceProtocol, didReceiveTrade trade: TradeRecord) {}
+    func realtimeServiceDidDetectStall(_ service: RealtimeServiceProtocol) {}
+}
+
+private final class MockWebSocketClientFactory: WebSocketClientFactory {
+    private var queues: [WebSocketChannel: [MockWebSocketClient]] = [:]
+
+    func enqueue(client: MockWebSocketClient, for channel: WebSocketChannel) {
+        var queue = queues[channel] ?? []
+        queue.append(client)
+        queues[channel] = queue
+    }
+
+    func makeClient(url: URL, headers: [String: String], channel: WebSocketChannel, delegate: WebSocketClientDelegate?) -> WebSocketClient {
+        guard var queue = queues[channel], !queue.isEmpty else {
+            fatalError("No mock client configured for channel \(channel)")
+        }
+        let client = queue.removeFirst()
+        queues[channel] = queue
+        client.delegate = delegate
+        return client
+    }
+}
+
+private final class MockWebSocketClient: WebSocketClient {
+    enum Event {
+        case message(Data)
+        case failure(Error)
+    }
+
+    weak var delegate: WebSocketClientDelegate?
+    private let channel: WebSocketChannel
+    private var events: [Event]
+
+    init(channel: WebSocketChannel, events: [Event]) {
+        self.channel = channel
+        self.events = events
+    }
+
+    func connect() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            guard let self else { return }
+            self.delegate?.webSocketClientDidOpen(self, channel: self.channel)
+            self.processNext()
+        }
+    }
+
+    func disconnect(with code: URLSessionWebSocketTask.CloseCode) {
+        events.removeAll()
+    }
+
+    private func processNext() {
+        guard !events.isEmpty else { return }
+        let event = events.removeFirst()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            guard let self else { return }
+            switch event {
+            case .message(let data):
+                self.delegate?.webSocketClient(self, channel: self.channel, didReceive: data)
+                self.processNext()
+            case .failure(let error):
+                self.delegate?.webSocketClient(self, channel: self.channel, didFailWith: error)
+            }
+        }
+    }
+}

--- a/ios/AidayTradingApp/project.yml
+++ b/ios/AidayTradingApp/project.yml
@@ -4,6 +4,10 @@ options:
   developmentRegion: en
   deploymentTarget:
     iOS: 16.0
+packages:
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk.git
+    from: 10.22.0
 settings:
   BASE_SDK: iphoneos
   SWIFT_VERSION: 5.9
@@ -18,6 +22,11 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.aidaytrading.app
       INFOPLIST_FILE: Sources/AidayTradingApp/Application/Info.plist
+    dependencies:
+      - package: Firebase
+        product: FirebaseMessaging
+      - package: Firebase
+        product: FirebaseCore
     scheme:
       testTargets:
         - AidayTradingAppTests


### PR DESCRIPTION
## Summary
- integrate Firebase messaging, AppDelegate bridging, and NotificationController to register push tokens and deep link tabs
- add a reusable realtime WebSocket service with reconnect logic, stall detection, and local notification fallback
- wire home and trades dashboards to live streams, show disconnect banners, and document/test the new behaviour

## Testing
- Not run (xcodebuild unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d74b6d1d6c832fb1b328c5b1936116