### PR TITLE
Feat: implement secure iOS auth and approval flow

### DIFF
--- a/ios/AidayTradingApp/README.md
+++ b/ios/AidayTradingApp/README.md
@@ -10,6 +10,7 @@ This SwiftUI application provides the secure mobile entry point for the AidayTra
 - Automatic session bootstrap with refresh token handling and biometric re-authentication.
 - Role-based UI that surfaces Admin tooling only for approved administrators.
 - Sensitive screen protections including Face ID / Touch ID gating, idle-timeout logout, and screen capture monitoring.
+- Guided password reset experience wired to `/auth/forgot-password` and delivered via secure email.
 - Unit and integration tests covering authentication, token handling, role detection, and approval workflow.
 - Viewer dashboards with equity charts, calendar PnL heatmap, and a paginated trade ledger consuming `/api/v1` reporting endpoints.
 - Real-time dashboards sourced from authenticated WebSocket feeds with automatic reconnect and disconnect banners.

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Application/SessionStore.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Application/SessionStore.swift
@@ -6,15 +6,15 @@ final class SessionStore: ObservableObject {
     enum SessionState: Equatable {
         case loading
         case loggedOut
-        case pendingApproval(email: String)
+        case pendingApproval(PendingApprovalContext)
         case authenticated(UserSessionContext)
 
         static func == (lhs: SessionStore.SessionState, rhs: SessionStore.SessionState) -> Bool {
             switch (lhs, rhs) {
             case (.loading, .loading), (.loggedOut, .loggedOut):
                 return true
-            case let (.pendingApproval(lEmail), .pendingApproval(rEmail)):
-                return lEmail == rEmail
+            case let (.pendingApproval(left), .pendingApproval(right)):
+                return left == right
             case let (.authenticated(lContext), .authenticated(rContext)):
                 return lContext.profile.id == rContext.profile.id && lContext.profile.role == rContext.profile.role
             default:
@@ -23,38 +23,54 @@ final class SessionStore: ObservableObject {
         }
     }
 
-    struct SessionError: Identifiable {
+    struct PendingApprovalContext: Equatable {
+        let username: String
+        let email: String
+        var tokens: AuthTokens?
+    }
+
+    struct SessionAlert: Identifiable {
         let id = UUID()
+        let title: String
         let message: String
     }
 
     @Published private(set) var state: SessionState
-    @Published var error: SessionError?
+    @Published var alert: SessionAlert?
 
     private let authService: AuthServiceProtocol
     private let tokenStorage: SecureTokenStorage
     private let biometricAuthenticator: BiometricAuthenticating
     private let idleManager: IdleTimeoutHandling
+    private let approvalService: ApprovalServiceProtocol
     private var hasBootstrapped = false
     private var isBiometricallyVerified = false
+    private var approvalPollingTask: Task<Void, Never>?
+    private var pendingApprovalContext: PendingApprovalContext?
 
     init(
         authService: AuthServiceProtocol = AuthService(),
         tokenStorage: SecureTokenStorage = KeychainStorage(),
         biometricAuthenticator: BiometricAuthenticating = BiometricAuthenticator(),
         idleManager: IdleTimeoutHandling = IdleTimeoutManager(timeout: 15 * 60),
+        approvalService: ApprovalServiceProtocol = ApprovalService(),
         previewState: SessionState = .loading
     ) {
         self.authService = authService
         self.tokenStorage = tokenStorage
         self.biometricAuthenticator = biometricAuthenticator
         self.idleManager = idleManager
+        self.approvalService = approvalService
         self.state = previewState
         self.idleManager.onTimeout = { [weak self] in
             Task { @MainActor in
                 self?.handleTimeout()
             }
         }
+    }
+
+    deinit {
+        approvalPollingTask?.cancel()
     }
 
     func bootstrap() async {
@@ -68,7 +84,9 @@ final class SessionStore: ObservableObject {
                     try tokenStorage.save(tokens: tokens)
                 }
                 let profile = try await authService.loadProfile(accessToken: tokens.accessToken)
-                try await enforceBiometricAuthentication()
+                if profile.approvalStatus == .approved {
+                    try await enforceBiometricAuthentication()
+                }
                 updateState(with: profile, tokens: tokens)
             } else {
                 state = .loggedOut
@@ -83,19 +101,22 @@ final class SessionStore: ObservableObject {
         state = .loading
         do {
             let profile = try await authService.signup(username: username, email: email, password: password)
-            state = .pendingApproval(email: profile.email)
+            let context = PendingApprovalContext(username: profile.username, email: profile.email, tokens: nil)
+            startApprovalPolling(with: context)
         } catch {
             await handleError(error)
             state = .loggedOut
         }
     }
 
-    func login(email: String, password: String) async {
+    func login(username: String, password: String) async {
         state = .loading
         do {
-            let context = try await authService.login(email: email, password: password)
+            let context = try await authService.login(username: username, password: password)
             try tokenStorage.save(tokens: context.tokens)
-            try await enforceBiometricAuthentication()
+            if context.profile.approvalStatus == .approved {
+                try await enforceBiometricAuthentication()
+            }
             updateState(with: context.profile, tokens: context.tokens)
         } catch {
             try? tokenStorage.delete()
@@ -115,6 +136,9 @@ final class SessionStore: ObservableObject {
                     try tokenStorage.save(tokens: tokens)
                 }
                 let profile = try await authService.loadProfile(accessToken: tokens.accessToken)
+                if profile.approvalStatus == .approved {
+                    try await enforceBiometricAuthentication()
+                }
                 updateState(with: profile, tokens: tokens)
             } catch {
                 await handleError(error)
@@ -122,11 +146,32 @@ final class SessionStore: ObservableObject {
         }
     }
 
+    func requestPasswordReset(email: String) {
+        Task {
+            do {
+                try await authService.requestPasswordReset(email: email)
+                await MainActor.run {
+                    self.alert = SessionAlert(title: "Reset email sent", message: "If an account exists for \(email), instructions are on the way.")
+                }
+            } catch {
+                await handleError(error)
+            }
+        }
+    }
+
     func logout() {
-        try? tokenStorage.delete()
-        idleManager.stop()
-        isBiometricallyVerified = false
-        state = .loggedOut
+        Task {
+            if let tokens = try? tokenStorage.load() {
+                try? await authService.logout(accessToken: tokens.accessToken)
+            }
+            try? tokenStorage.delete()
+            await MainActor.run {
+                self.stopApprovalPolling()
+                self.idleManager.stop()
+                self.isBiometricallyVerified = false
+                self.state = .loggedOut
+            }
+        }
     }
 
     func handleScenePhaseChange(_ phase: ScenePhase) {
@@ -134,8 +179,10 @@ final class SessionStore: ObservableObject {
         case .active:
             if case .authenticated = state {
                 idleManager.start()
+                Task { try? await enforceBiometricAuthentication() }
             }
-        case .background:
+        case .background, .inactive:
+            isBiometricallyVerified = false
             idleManager.stop()
         default:
             break
@@ -143,26 +190,31 @@ final class SessionStore: ObservableObject {
     }
 
     func registerInteraction() {
-        idleManager.reset()
+        if case .authenticated = state {
+            idleManager.reset()
+        }
     }
 
     private func updateState(with profile: UserProfile, tokens: AuthTokens) {
         switch profile.approvalStatus {
         case .approved:
+            stopApprovalPolling()
             let context = UserSessionContext(profile: profile, tokens: tokens)
             state = .authenticated(context)
             idleManager.start()
         case .pending:
-            state = .pendingApproval(email: profile.email)
+            let context = PendingApprovalContext(username: profile.username, email: profile.email, tokens: tokens)
+            startApprovalPolling(with: context)
         case .rejected:
+            stopApprovalPolling()
             state = .loggedOut
-            error = SessionError(message: "Your account request was rejected. Contact support for assistance.")
+            alert = SessionAlert(title: "Access denied", message: "Your account request was rejected. Contact support for assistance.")
         }
     }
 
     private func handleTimeout() {
         logout()
-        error = SessionError(message: "You have been logged out due to inactivity.")
+        alert = SessionAlert(title: "Session expired", message: "You have been logged out due to inactivity.")
     }
 
     private func enforceBiometricAuthentication() async throws {
@@ -171,13 +223,82 @@ final class SessionStore: ObservableObject {
         isBiometricallyVerified = true
     }
 
+    private func startApprovalPolling(with context: PendingApprovalContext) {
+        pendingApprovalContext = context
+        state = .pendingApproval(context)
+        approvalPollingTask?.cancel()
+        approvalPollingTask = Task { [weak self] in
+            await self?.pollApprovalStatus()
+        }
+    }
+
+    private func stopApprovalPolling() {
+        approvalPollingTask?.cancel()
+        approvalPollingTask = nil
+        pendingApprovalContext = nil
+    }
+
+    private func pollApprovalStatus() async {
+        while !Task.isCancelled {
+            guard let context = await MainActor.run(body: { self.pendingApprovalContext }) else {
+                return
+            }
+            await checkApprovalStatus(for: context)
+            try? await Task.sleep(nanoseconds: 30 * NSEC_PER_SEC)
+        }
+    }
+
+    private func checkApprovalStatus(for context: PendingApprovalContext) async {
+        do {
+            if var tokens = context.tokens {
+                if !tokens.isAccessTokenValid {
+                    tokens = try await authService.refresh(using: tokens.refreshToken)
+                    try tokenStorage.save(tokens: tokens)
+                    await MainActor.run {
+                        self.pendingApprovalContext?.tokens = tokens
+                    }
+                }
+                let profile = try await authService.loadProfile(accessToken: tokens.accessToken)
+                if profile.approvalStatus == .approved {
+                    await MainActor.run {
+                        self.updateState(with: profile, tokens: tokens)
+                    }
+                } else if profile.approvalStatus == .rejected {
+                    await MainActor.run {
+                        self.stopApprovalPolling()
+                        self.state = .loggedOut
+                        self.alert = SessionAlert(title: "Access denied", message: "Your account request was rejected. Contact support for assistance.")
+                    }
+                }
+            } else {
+                let status = try await approvalService.fetchStatus(username: context.username, email: context.email)
+                await MainActor.run {
+                    switch status {
+                    case .approved:
+                        self.stopApprovalPolling()
+                        self.state = .loggedOut
+                        self.alert = SessionAlert(title: "Account approved", message: "Your account has been approved. Please sign in to continue.")
+                    case .rejected:
+                        self.stopApprovalPolling()
+                        self.state = .loggedOut
+                        self.alert = SessionAlert(title: "Access denied", message: "Your account request was rejected. Contact support for assistance.")
+                    case .pending:
+                        break
+                    }
+                }
+            }
+        } catch {
+            await handleError(error)
+        }
+    }
+
     private func handleError(_ error: Error) async {
         if let apiError = error as? APIErrorResponse {
-            self.error = SessionError(message: apiError.message)
+            self.alert = SessionAlert(title: "Request failed", message: apiError.message)
         } else if let localized = error as? LocalizedError, let message = localized.errorDescription {
-            self.error = SessionError(message: message)
+            self.alert = SessionAlert(title: "Request failed", message: message)
         } else {
-            self.error = SessionError(message: "An unexpected error occurred. Please try again.")
+            self.alert = SessionAlert(title: "Unexpected error", message: "An unexpected error occurred. Please try again.")
         }
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/AuthenticationFlowView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/AuthenticationFlowView.swift
@@ -11,6 +11,7 @@ struct AuthenticationFlowView: View {
             .navigationDestination(isPresented: $isPresentingSignup) {
                 SignupView()
             }
+            .toolbar(.hidden, for: .automatic)
         }
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/LoginView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/LoginView.swift
@@ -2,60 +2,142 @@ import SwiftUI
 
 struct LoginView: View {
     @EnvironmentObject private var session: SessionStore
-    @State private var email: String = ""
+    @State private var username: String = ""
     @State private var password: String = ""
     @State private var isSubmitting = false
+    @State private var isPresentingResetSheet = false
+    @State private var resetEmail: String = ""
 
     let onSignup: () -> Void
 
     var body: some View {
-        Form {
-            Section(header: Text("Credentials")) {
-                TextField("Email", text: $email)
-                    .keyboardType(.emailAddress)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                SecureField("Password", text: $password)
-            }
+        ScrollView {
+            VStack(spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Welcome back")
+                        .font(.largeTitle.bold())
+                        .foregroundStyle(.white)
+                    Text("Sign in to monitor live equity, trades, and risk controls.")
+                        .font(.callout)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                VStack(spacing: 16) {
+                    inputField(title: "Username", text: $username, icon: "person", isSecure: false)
+                    inputField(title: "Password", text: $password, icon: "lock", isSecure: true)
+                }
+                .padding()
+                .background(Theme.cardBackground, in: RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Theme.accentGreen.opacity(0.4), lineWidth: 1)
+                )
 
-            Section {
-                Button(action: login) {
+                Button {
+                    submit()
+                } label: {
                     if isSubmitting {
                         ProgressView()
+                            .tint(.white)
                     } else {
-                        Text("Login")
+                        Text("Secure login")
+                            .bold()
                     }
                 }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accentGreen)
                 .disabled(!formIsValid || isSubmitting)
 
-                Button("Create account") {
-                    onSignup()
+                HStack {
+                    Button("Forgot password?") {
+                        resetEmail = ""
+                        isPresentingResetSheet = true
+                    }
+                    .tint(.white)
+                    Spacer()
+                    Button("Request access") {
+                        onSignup()
+                    }
+                    .tint(Theme.accentGreen)
                 }
-                .buttonStyle(.borderless)
+                .font(.footnote)
             }
+            .padding(.horizontal, 24)
+            .padding(.top, 80)
+            .padding(.bottom, 32)
         }
-        .navigationTitle("Welcome back")
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("Reset form") {
-                    email = ""
-                    password = ""
-                }
-            }
+        .background(Theme.background.ignoresSafeArea())
+        .customNavigationBar(title: "AidayTrading")
+        .sheet(isPresented: $isPresentingResetSheet) {
+            resetSheet
         }
     }
 
     private var formIsValid: Bool {
-        !email.isEmpty && !password.isEmpty
+        !username.isEmpty && !password.isEmpty
     }
 
-    private func login() {
+    private func inputField(title: String, text: Binding<String>, icon: String, isSecure: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.7))
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(Theme.accentGreen)
+                if isSecure {
+                    SecureField(title, text: text)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .foregroundStyle(.white)
+                } else {
+                    TextField(title, text: text)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .foregroundStyle(.white)
+                }
+            }
+            .padding()
+            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private func submit() {
         guard formIsValid else { return }
         isSubmitting = true
+        session.registerInteraction()
         Task {
-            await session.login(email: email, password: password)
+            await session.login(username: username, password: password)
             await MainActor.run {
                 isSubmitting = false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var resetSheet: some View {
+        NavigationStack {
+            Form {
+                Section("Reset password") {
+                    TextField("Account email", text: $resetEmail)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                Section {
+                    Button("Send reset link") {
+                        session.requestPasswordReset(email: resetEmail)
+                        isPresentingResetSheet = false
+                    }
+                    .disabled(resetEmail.isEmpty || !resetEmail.contains("@"))
+                }
+            }
+            .navigationTitle("Forgot password")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        isPresentingResetSheet = false
+                    }
+                }
             }
         }
     }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/SignupView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Authentication/SignupView.swift
@@ -9,62 +9,122 @@ struct SignupView: View {
     @State private var isSubmitting = false
 
     var body: some View {
-        Form {
-            Section(header: Text("Account details")) {
-                TextField("Username", text: $username)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                TextField("Email", text: $email)
-                    .keyboardType(.emailAddress)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                SecureField("Password", text: $password)
-                SecureField("Confirm Password", text: $confirmPassword)
-            }
+        ScrollView {
+            VStack(spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Request secure access")
+                        .font(.largeTitle.bold())
+                        .foregroundStyle(.white)
+                    Text("Provide contact details so we can verify your identity before enabling live trading dashboards.")
+                        .font(.callout)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
 
-            Section(footer: passwordRequirementsView) {
-                Button(action: signup) {
-                    if isSubmitting {
-                        ProgressView()
-                    } else {
-                        Text("Request access")
+                VStack(spacing: 16) {
+                    floatingField(title: "Username", text: $username, icon: "person")
+                    floatingField(title: "Email", text: $email, icon: "envelope")
+                        .keyboardType(.emailAddress)
+                    floatingSecureField(title: "Password", text: $password, icon: "lock")
+                    floatingSecureField(title: "Confirm password", text: $confirmPassword, icon: "lock.rotation")
+                }
+                .padding()
+                .background(Theme.cardBackground, in: RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Theme.accentGreen.opacity(0.4), lineWidth: 1)
+                )
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Password requirements")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    ForEach(passwordStrength.messages, id: \.self) { message in
+                        HStack {
+                            Image(systemName: passwordStrength.isValid ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                                .foregroundStyle(passwordStrength.isValid ? Theme.accentGreen : Theme.accentRed)
+                            Text(message)
+                                .foregroundStyle(.white.opacity(0.8))
+                                .font(.subheadline)
+                        }
                     }
                 }
+
+                Button {
+                    submit()
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("Submit for approval")
+                            .bold()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accentGreen)
                 .disabled(!formIsValid || isSubmitting)
             }
+            .padding(.horizontal, 24)
+            .padding(.top, 80)
+            .padding(.bottom, 32)
         }
-        .navigationTitle("Create account")
-    }
-
-    private var formIsValid: Bool {
-        !username.isEmpty && email.contains("@") && passwordStrength.isValid && password == confirmPassword
+        .background(Theme.background.ignoresSafeArea())
+        .customNavigationBar(title: "Create account")
     }
 
     private var passwordStrength: PasswordStrengthValidator.ValidationResult {
         PasswordStrengthValidator.validate(password: password)
     }
 
-    @ViewBuilder
-    private var passwordRequirementsView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Password must contain:")
-                .font(.footnote)
-            ForEach(passwordStrength.messages, id: \.self) { message in
-                Label(message, systemImage: passwordStrength.isValid ? "checkmark.circle" : "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(passwordStrength.isValid ? .green : .orange)
-            }
-        }
+    private var formIsValid: Bool {
+        !username.isEmpty && email.contains("@") && passwordStrength.isValid && password == confirmPassword
     }
 
-    private func signup() {
+    private func submit() {
         guard formIsValid else { return }
         isSubmitting = true
+        session.registerInteraction()
         Task {
             await session.signup(username: username, email: email, password: password)
             await MainActor.run {
                 isSubmitting = false
             }
+        }
+    }
+
+    private func floatingField(title: String, text: Binding<String>, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.7))
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(Theme.accentGreen)
+                TextField(title, text: text)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(.white)
+            }
+            .padding()
+            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private func floatingSecureField(title: String, text: Binding<String>, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.7))
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(Theme.accentGreen)
+                SecureField(title, text: text)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(.white)
+            }
+            .padding()
+            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
         }
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/CustomNavBar.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/CustomNavBar.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct CustomNavBar<Content: View>: View {
+    let title: String
+    @ViewBuilder var trailing: () -> Content
+
+    init(title: String, @ViewBuilder trailing: @escaping () -> Content = { EmptyView() }) {
+        self.title = title
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.white)
+            Spacer()
+            trailing()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 48)
+        .padding(.bottom, 16)
+        .background(Theme.background.opacity(0.95))
+    }
+}
+
+extension View {
+    func customNavigationBar<Trailing: View>(title: String, @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }) -> some View {
+        modifier(CustomNavBarModifier(title: title, trailing: trailing))
+    }
+}
+
+private struct CustomNavBarModifier<Trailing: View>: ViewModifier {
+    let title: String
+    @ViewBuilder var trailing: () -> Trailing
+
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            CustomNavBar(title: title, trailing: trailing)
+            content
+        }
+        .background(Theme.background)
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/RootView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Common/RootView.swift
@@ -10,19 +10,20 @@ struct RootView: View {
                 ProgressView("Loading session…")
             case .loggedOut:
                 AuthenticationFlowView()
-            case .pendingApproval(let email):
-                PendingApprovalView(email: email) {
+            case .pendingApproval(let context):
+                PendingApprovalView(context: context) {
                     session.refreshProfile()
                 }
             case .authenticated(let context):
                 MainTabView(context: context)
             }
         }
+        .background(Theme.background.ignoresSafeArea())
         .task {
             await session.bootstrap()
         }
-        .alert(item: $session.error) { error in
-            Alert(title: Text("Error"), message: Text(error.message), dismissButton: .default(Text("OK")))
+        .alert(item: $session.alert) { alert in
+            Alert(title: Text(alert.title), message: Text(alert.message), dismissButton: .default(Text("OK")))
         }
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/Main/MainTabView.swift
@@ -23,28 +23,20 @@ struct MainTabView: View {
     var body: some View {
         TabView(selection: $selection) {
             HomeView(context: context, reportingService: reportingService)
-                .tabItem {
-                    Label("Home", systemImage: "chart.line.uptrend.xyaxis")
-                }
+                .tabItem { Label("Home", systemImage: "chart.line.uptrend.xyaxis") }
                 .tag(Tab.home)
 
             CalendarView(context: context, reportingService: reportingService)
-                .tabItem {
-                    Label("Calendar", systemImage: "calendar")
-                }
+                .tabItem { Label("Calendar", systemImage: "calendar") }
                 .tag(Tab.calendar)
 
             TradesView(context: context, reportingService: reportingService)
-                .tabItem {
-                    Label("Trades", systemImage: "list.bullet.rectangle")
-                }
+                .tabItem { Label("Trades", systemImage: "list.bullet.rectangle") }
                 .tag(Tab.trades)
 
-            if context.profile.role == .admin {
+            if RoleManager.isAdmin(context.profile) {
                 AdminView()
-                    .tabItem {
-                        Label("Admin", systemImage: "lock.shield")
-                    }
+                    .tabItem { Label("Admin", systemImage: "lock.shield") }
                     .tag(Tab.admin)
             }
         }
@@ -58,7 +50,9 @@ struct MainTabView: View {
         }
         .onChange(of: notificationController.pendingTab) { _, newValue in
             guard let tab = newValue else { return }
-            selection = tab
+            if RoleManager.accessibleTabs(for: context.profile).contains(tab) {
+                selection = tab
+            }
             _ = notificationController.consumePendingTab()
         }
         .toolbar {

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Features/PendingApproval/PendingApprovalView.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Features/PendingApproval/PendingApprovalView.swift
@@ -1,36 +1,93 @@
 import SwiftUI
 
 struct PendingApprovalView: View {
-    let email: String
+    let context: SessionStore.PendingApprovalContext
     let onRefresh: () -> Void
     @EnvironmentObject private var session: SessionStore
+    @State private var isRefreshing = false
 
     var body: some View {
-        VStack(spacing: 24) {
-            Image(systemName: "hourglass")
-                .font(.system(size: 48))
-                .foregroundStyle(.accent)
-            Text("Account pending approval")
-                .font(.title2)
-                .bold()
-            Text("We have received your request. An administrator will review your account and notify you via email at \(email).")
-                .font(.body)
-                .multilineTextAlignment(.center)
-            Button("Refresh status") {
-                onRefresh()
+        ScrollView {
+            VStack(spacing: 24) {
+                Image(systemName: "hourglass.circle.fill")
+                    .font(.system(size: 72))
+                    .foregroundStyle(Theme.accentGreen)
+                    .padding(.top, 32)
+                VStack(spacing: 8) {
+                    Text("Your account is awaiting review")
+                        .font(.title2)
+                        .bold()
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                    Text("Thanks for joining, \(context.username).").foregroundStyle(.white.opacity(0.8))
+                    Text("We notify our trading desk immediately. You'll receive an email at \(context.email) once we're done.")
+                        .font(.callout)
+                        .foregroundStyle(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Status: Pending manual approval", systemImage: "clock")
+                        .foregroundStyle(.white)
+                    Label("Security: Trading data stays locked until approval", systemImage: "lock.shield")
+                        .foregroundStyle(.white)
+                    Label("Checks run automatically every 30 seconds", systemImage: "arrow.clockwise")
+                        .foregroundStyle(.white)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(Theme.cardBackground, in: RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Theme.accentGreen.opacity(0.4), lineWidth: 1)
+                )
+                Button {
+                    guard !isRefreshing else { return }
+                    isRefreshing = true
+                    session.registerInteraction()
+                    Task {
+                        onRefresh()
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        await MainActor.run {
+                            isRefreshing = false
+                        }
+                    }
+                } label: {
+                    if isRefreshing {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("Check status now")
+                            .bold()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accentGreen)
+
+                Button(role: .destructive) {
+                    session.logout()
+                } label: {
+                    Text("Log out")
+                        .bold()
+                }
+                .buttonStyle(.bordered)
+                .tint(Theme.accentRed)
+                .padding(.bottom, 40)
             }
-            .buttonStyle(.borderedProminent)
-            Button("Logout") {
-                session.logout()
-            }
-            .tint(.red)
+            .padding(.horizontal, 24)
         }
-        .padding()
-        .multilineTextAlignment(.center)
+        .background(Theme.background.ignoresSafeArea())
+        .customNavigationBar(title: "Awaiting approval")
+        .onAppear {
+            session.registerInteraction()
+        }
     }
 }
 
 #Preview {
-    PendingApprovalView(email: "trader@example.com", onRefresh: {})
-        .environmentObject(SessionStore(previewState: .pendingApproval(email: "trader@example.com")))
+    PendingApprovalView(
+        context: SessionStore.PendingApprovalContext(username: "trader", email: "trader@example.com", tokens: nil),
+        onRefresh: {}
+    )
+    .environmentObject(SessionStore(previewState: .pendingApproval(.init(username: "trader", email: "trader@example.com", tokens: nil))))
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ApprovalRequests.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ApprovalRequests.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum ApprovalRequest: APIRequestConvertible {
+    case status(username: String, email: String)
+
+    var urlRequest: URLRequest {
+        get throws {
+            switch self {
+            case let .status(username, email):
+                var components = URLComponents(url: APIEnvironment.baseURL.appending(path: "/auth/status"), resolvingAgainstBaseURL: false)
+                components?.queryItems = [
+                    URLQueryItem(name: "username", value: username),
+                    URLQueryItem(name: "email", value: email)
+                ]
+                guard let url = components?.url else {
+                    throw URLError(.badURL)
+                }
+                var request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.addValue("application/json", forHTTPHeaderField: "Accept")
+                return request
+            }
+        }
+    }
+}
+
+struct ApprovalStatusResponse: Decodable {
+    let status: UserProfile.ApprovalStatus
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ApprovalService.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/ApprovalService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol ApprovalServiceProtocol {
+    func fetchStatus(username: String, email: String) async throws -> UserProfile.ApprovalStatus
+}
+
+struct ApprovalService: ApprovalServiceProtocol {
+    private let apiClient: APIClientProtocol
+
+    init(apiClient: APIClientProtocol = APIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func fetchStatus(username: String, email: String) async throws -> UserProfile.ApprovalStatus {
+        let response: ApprovalStatusResponse = try await apiClient.send(
+            ApprovalRequest.status(username: username, email: email),
+            decode: ApprovalStatusResponse.self
+        )
+        return response.status
+    }
+}

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/AuthRequests.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/AuthRequests.swift
@@ -2,9 +2,11 @@ import Foundation
 
 enum AuthRequest: APIRequestConvertible {
     case signup(username: String, email: String, password: String)
-    case login(email: String, password: String)
+    case login(username: String, password: String)
     case refresh(refreshToken: String)
     case profile(accessToken: String)
+    case logout(accessToken: String)
+    case forgotPassword(email: String)
 
     var urlRequest: URLRequest {
         get throws {
@@ -19,12 +21,12 @@ enum AuthRequest: APIRequestConvertible {
                     "email": email,
                     "password": password
                 ])
-            case let .login(email, password):
+            case let .login(username, password):
                 let url = APIEnvironment.baseURL.appending(path: "/auth/login")
                 request = URLRequest(url: url)
                 request.httpMethod = "POST"
                 request.httpBody = try JSONEncoder().encode([
-                    "email": email,
+                    "username": username,
                     "password": password
                 ])
             case let .refresh(refreshToken):
@@ -39,6 +41,18 @@ enum AuthRequest: APIRequestConvertible {
                 request = URLRequest(url: url)
                 request.httpMethod = "GET"
                 request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            case let .logout(accessToken):
+                let url = APIEnvironment.baseURL.appending(path: "/auth/logout")
+                request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            case let .forgotPassword(email):
+                let url = APIEnvironment.baseURL.appending(path: "/auth/forgot-password")
+                request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.httpBody = try JSONEncoder().encode([
+                    "email": email
+                ])
             }
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.addValue("application/json", forHTTPHeaderField: "Accept")

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Services/AuthService.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Services/AuthService.swift
@@ -2,9 +2,11 @@ import Foundation
 
 protocol AuthServiceProtocol {
     func signup(username: String, email: String, password: String) async throws -> UserProfile
-    func login(email: String, password: String) async throws -> UserSessionContext
+    func login(username: String, password: String) async throws -> UserSessionContext
     func refresh(using refreshToken: String) async throws -> AuthTokens
     func loadProfile(accessToken: String) async throws -> UserProfile
+    func logout(accessToken: String) async throws
+    func requestPasswordReset(email: String) async throws
 }
 
 struct AuthService: AuthServiceProtocol {
@@ -19,8 +21,8 @@ struct AuthService: AuthServiceProtocol {
         return response.user
     }
 
-    func login(email: String, password: String) async throws -> UserSessionContext {
-        let response: AuthResponse = try await apiClient.send(AuthRequest.login(email: email, password: password), decode: AuthResponse.self)
+    func login(username: String, password: String) async throws -> UserSessionContext {
+        let response: AuthResponse = try await apiClient.send(AuthRequest.login(username: username, password: password), decode: AuthResponse.self)
         return UserSessionContext(profile: response.user, tokens: response.tokens)
     }
 
@@ -31,5 +33,13 @@ struct AuthService: AuthServiceProtocol {
 
     func loadProfile(accessToken: String) async throws -> UserProfile {
         try await apiClient.send(AuthRequest.profile(accessToken: accessToken), decode: UserProfile.self)
+    }
+
+    func logout(accessToken: String) async throws {
+        try await apiClient.send(AuthRequest.logout(accessToken: accessToken))
+    }
+
+    func requestPasswordReset(email: String) async throws {
+        try await apiClient.send(AuthRequest.forgotPassword(email: email))
     }
 }

--- a/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/RoleManager.swift
+++ b/ios/AidayTradingApp/Sources/AidayTradingApp/Utilities/RoleManager.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum RoleManager {
+    static func isAdmin(_ profile: UserProfile) -> Bool {
+        profile.role == .admin
+    }
+
+    static func canApproveUsers(_ profile: UserProfile) -> Bool {
+        isAdmin(profile)
+    }
+
+    static func accessibleTabs(for profile: UserProfile) -> [MainTabView.Tab] {
+        if isAdmin(profile) {
+            return [.home, .calendar, .trades, .admin]
+        }
+        return [.home, .calendar, .trades]
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/AuthenticationSnapshotTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/AuthenticationSnapshotTests.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import XCTest
+@testable import AidayTradingApp
+
+#if canImport(SwiftUI)
+
+@MainActor
+final class AuthenticationSnapshotTests: XCTestCase {
+    func testLoginViewRendersSnapshot() throws {
+        let view = LoginView(onSignup: {})
+            .environmentObject(SessionStore(previewState: .loggedOut))
+        let renderer = ImageRenderer(content: view.frame(width: 390, height: 844))
+
+        #if canImport(UIKit)
+        XCTAssertNotNil(renderer.uiImage)
+        #elseif canImport(AppKit)
+        XCTAssertNotNil(renderer.nsImage)
+        #else
+        throw XCTSkip("Snapshot rendering not supported on this platform")
+        #endif
+    }
+
+    func testPendingApprovalViewRendersSnapshot() throws {
+        let context = SessionStore.PendingApprovalContext(username: "snapshot", email: "snapshot@example.com", tokens: nil)
+        let view = PendingApprovalView(context: context, onRefresh: {})
+            .environmentObject(SessionStore(previewState: .pendingApproval(context)))
+        let renderer = ImageRenderer(content: view.frame(width: 390, height: 844))
+
+        #if canImport(UIKit)
+        XCTAssertNotNil(renderer.uiImage)
+        #elseif canImport(AppKit)
+        XCTAssertNotNil(renderer.nsImage)
+        #else
+        throw XCTSkip("Snapshot rendering not supported on this platform")
+        #endif
+    }
+}
+
+#endif

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/KeychainStorageTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/KeychainStorageTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import AidayTradingApp
+
+final class KeychainStorageTests: XCTestCase {
+    func testRoundTripPersistsTokens() throws {
+        #if canImport(Security)
+        let storage = KeychainStorage()
+        let tokens = AuthTokens(accessToken: "access-token", refreshToken: "refresh-token", accessTokenExpiry: Date().addingTimeInterval(3600))
+
+        try storage.delete()
+        try storage.save(tokens: tokens)
+        let loaded = try storage.load()
+        XCTAssertEqual(loaded?.accessToken, tokens.accessToken)
+        XCTAssertEqual(loaded?.refreshToken, tokens.refreshToken)
+
+        try storage.delete()
+        XCTAssertNil(try storage.load())
+        #else
+        throw XCTSkip("Security framework unavailable on this platform")
+        #endif
+    }
+}

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/Mocks.swift
@@ -6,12 +6,14 @@ final class MockAuthService: AuthServiceProtocol {
     var signupResult: Result<UserProfile, Error> = .failure(MockError.notConfigured)
     var refreshResult: Result<AuthTokens, Error> = .failure(MockError.notConfigured)
     var profileResult: Result<UserProfile, Error> = .failure(MockError.notConfigured)
+    var logoutCalled = false
+    var passwordResetEmails: [String] = []
 
     func signup(username: String, email: String, password: String) async throws -> UserProfile {
         try await signupResult.get()
     }
 
-    func login(email: String, password: String) async throws -> UserSessionContext {
+    func login(username: String, password: String) async throws -> UserSessionContext {
         try await loginResult.get()
     }
 
@@ -21,6 +23,14 @@ final class MockAuthService: AuthServiceProtocol {
 
     func loadProfile(accessToken: String) async throws -> UserProfile {
         try await profileResult.get()
+    }
+
+    func logout(accessToken: String) async throws {
+        logoutCalled = true
+    }
+
+    func requestPasswordReset(email: String) async throws {
+        passwordResetEmails.append(email)
     }
 }
 
@@ -76,6 +86,14 @@ final class MockIdleTimeoutManager: IdleTimeoutHandling {
 enum MockError: Error {
     case notConfigured
     case biometricFailed
+}
+
+final class MockApprovalService: ApprovalServiceProtocol {
+    var statusResult: Result<UserProfile.ApprovalStatus, Error> = .failure(MockError.notConfigured)
+
+    func fetchStatus(username: String, email: String) async throws -> UserProfile.ApprovalStatus {
+        try await statusResult.get()
+    }
 }
 
 final class MockLocalNotificationScheduler: LocalNotificationScheduling {

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/RoleDetectionTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/RoleDetectionTests.swift
@@ -6,6 +6,8 @@ final class RoleDetectionTests: XCTestCase {
         let profile = UserProfile(id: UUID(), username: "Viewer", email: "viewer@example.com", role: .viewer, approvalStatus: .approved)
         let tokens = AuthTokens(accessToken: "token", refreshToken: "refresh", accessTokenExpiry: .distantFuture)
         let context = UserSessionContext(profile: profile, tokens: tokens)
+        XCTAssertEqual(RoleManager.accessibleTabs(for: profile), [.home, .calendar, .trades])
+        XCTAssertFalse(RoleManager.canApproveUsers(profile))
         let view = MainTabView(context: context)
         XCTAssertNotNil(view)
     }
@@ -14,7 +16,8 @@ final class RoleDetectionTests: XCTestCase {
         let profile = UserProfile(id: UUID(), username: "Admin", email: "admin@example.com", role: .admin, approvalStatus: .approved)
         let tokens = AuthTokens(accessToken: "token", refreshToken: "refresh", accessTokenExpiry: .distantFuture)
         let context = UserSessionContext(profile: profile, tokens: tokens)
-        let view = MainTabView(context: context)
-        XCTAssertNotNil(view)
+        XCTAssertEqual(RoleManager.accessibleTabs(for: profile), [.home, .calendar, .trades, .admin])
+        XCTAssertTrue(RoleManager.canApproveUsers(profile))
+        XCTAssertNotNil(MainTabView(context: context))
     }
 }

--- a/ios/AidayTradingApp/Tests/AidayTradingAppTests/SignupApprovalIntegrationTests.swift
+++ b/ios/AidayTradingApp/Tests/AidayTradingAppTests/SignupApprovalIntegrationTests.swift
@@ -18,16 +18,17 @@ final class SignupApprovalIntegrationTests: XCTestCase {
             tokenStorage: MockTokenStorage(),
             biometricAuthenticator: MockBiometricAuthenticator(),
             idleManager: MockIdleTimeoutManager(),
+            approvalService: MockApprovalService(),
             previewState: .loggedOut
         )
 
         await session.signup(username: "NewUser", email: pendingProfile.email, password: "Password1")
-        guard case let .pendingApproval(email) = session.state else {
+        guard case let .pendingApproval(pendingContext) = session.state else {
             return XCTFail("Expected pending approval state")
         }
-        XCTAssertEqual(email, pendingProfile.email)
+        XCTAssertEqual(pendingContext.email, pendingProfile.email)
 
-        await session.login(email: approvedProfile.email, password: "Password1")
+        await session.login(username: approvedProfile.username, password: "Password1")
         guard case let .authenticated(authenticatedContext) = session.state else {
             return XCTFail("Expected authenticated state")
         }


### PR DESCRIPTION
## Summary
- redesign the SwiftUI authentication experience with theming, password reset, and custom navigation chrome
- harden SessionStore with biometric reauth, approval polling, logout revocation, and role utilities
- add Brevo approval polling services, keychain unit tests, role checks, and snapshot coverage for login and pending screens

## Testing
- Not Run (environment does not provide Xcode tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d757cff88c832fbf7bfbaa52841a16