### PR TITLE
Enhance SQLite durability and add backup tooling

### DIFF
--- a/scripts/backup_sqlite.py
+++ b/scripts/backup_sqlite.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""Utility for creating consistent SQLite backups using the native backup API."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_DATABASE = Path("ai_trader/data/trades.db")
+
+
+def backup_sqlite(source: Path, destination: Path) -> Path:
+    """Copy ``source`` to ``destination`` using the SQLite backup API."""
+
+    if not source.exists():
+        raise FileNotFoundError(f"SQLite database not found: {source}")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with sqlite3.connect(source) as source_conn:
+            with sqlite3.connect(destination) as destination_conn:
+                source_conn.backup(destination_conn)
+                destination_conn.commit()
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"Failed to backup SQLite database: {exc}") from exc
+
+    LOGGER.info("SQLite backup written to %s", destination)
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a hot backup of the SQLite trade log.")
+    parser.add_argument(
+        "db_path",
+        type=Path,
+        nargs="?",
+        default=DEFAULT_DATABASE,
+        help="Path to the source SQLite database (default: ai_trader/data/trades.db)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional destination path. Defaults to ai_trader/data/backups/<db>-<timestamp>.bak",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = parse_args()
+
+    source = args.db_path.resolve()
+    destination: Optional[Path]
+    if args.output:
+        destination = args.output.resolve()
+    else:
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        destination = source.parent / "backups" / f"{source.stem}-{timestamp}.bak"
+
+    try:
+        backup_sqlite(source, destination)
+    except Exception as exc:  # noqa: BLE001 - surface the failure for operator awareness
+        LOGGER.exception("SQLite backup failed: %s", exc)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sqlite_resilience.py
+++ b/tests/test_sqlite_resilience.py
@@ -1,0 +1,84 @@
+"""Regression tests for SQLite durability improvements."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from typing import Iterator
+
+from ai_trader.services.trade_log import TradeLog
+from ai_trader.services.types import TradeIntent
+
+
+def test_trade_log_enables_wal_mode(tmp_path) -> None:
+    """WAL mode should be activated on initialisation for safer concurrency."""
+
+    db_path = tmp_path / "trades.db"
+    TradeLog(db_path)
+
+    with sqlite3.connect(db_path) as connection:
+        mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
+
+    assert str(mode).lower() == "wal"
+
+
+def test_trade_log_retries_on_locked_writes(monkeypatch, tmp_path) -> None:
+    """Simulate a transient lock and ensure the trade insert is retried."""
+
+    db_path = tmp_path / "trades.db"
+    trade_log = TradeLog(db_path)
+
+    original_connect = TradeLog._connect
+    proxy_state: dict[str, "ProxyConnection"] = {}
+
+    class ProxyConnection:
+        def __init__(self, real_conn: sqlite3.Connection) -> None:
+            self._inner = real_conn
+            self.insert_calls = 0
+
+        def execute(self, statement: str, parameters=()):
+            if (
+                statement.strip().upper().startswith("INSERT INTO TRADES")
+                and self.insert_calls == 0
+            ):
+                self.insert_calls += 1
+                raise sqlite3.OperationalError("database is locked")
+            self.insert_calls += 1
+            return self._inner.execute(statement, parameters)
+
+        def rollback(self) -> None:
+            self._inner.rollback()
+
+        def commit(self) -> None:
+            self._inner.commit()
+
+        def __getattr__(self, item):
+            return getattr(self._inner, item)
+
+    @contextmanager
+    def flaky_connect(self) -> Iterator[sqlite3.Connection]:
+        with original_connect(self) as real_conn:
+            proxy = ProxyConnection(real_conn)
+            proxy_state["proxy"] = proxy
+            yield proxy
+
+    monkeypatch.setattr(TradeLog, "_connect", flaky_connect)
+
+    trade = TradeIntent(
+        worker="test-worker",
+        action="OPEN",
+        symbol="BTC/USD",
+        side="buy",
+        cash_spent=100.0,
+        entry_price=25000.0,
+    )
+
+    trade_log.record_trade(trade)
+
+    proxy = proxy_state["proxy"]
+    assert isinstance(proxy, ProxyConnection)
+    assert proxy.insert_calls >= 2
+
+    with sqlite3.connect(db_path) as connection:
+        count = connection.execute("SELECT COUNT(1) FROM trades").fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Summary
- enable WAL mode and retry/backoff for SQLite writes in the trade log
- add a backup_sqlite utility script and document hot-backup guidance in the README
- cover WAL activation and retry behaviour with a new regression test

## Testing
- black ai_trader/services/trade_log.py scripts/backup_sqlite.py tests/test_sqlite_resilience.py
- flake8
- pytest tests/test_sqlite_resilience.py -q
- pytest -q *(fails: async plugin such as pytest-asyncio is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d841724b5c832fa482e492e688d05f