### PR TITLE
Feat: align investor API with mobile contract

### DIFF
--- a/backend/app/api/trades.py
+++ b/backend/app/api/trades.py
@@ -1,6 +1,8 @@
 """Trade endpoints."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,14 +17,38 @@ router = APIRouter(prefix="/trades", tags=["trades"])
 
 @router.get("", response_model=TradePage)
 async def list_trades(
-    limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    symbol: str | None = Query(None, min_length=1),
+    side: str | None = Query(None, min_length=3, max_length=5),
+    start: datetime | None = Query(None),
+    end: datetime | None = Query(None),
     session: AsyncSession = Depends(get_db),
     user=Depends(get_current_user),
 ) -> TradePage:
-    result = await session.execute(
-        select(Trade).order_by(Trade.executed_at.desc()).offset(offset).limit(limit)
-    )
+    filters = []
+    if symbol:
+        filters.append(Trade.symbol == symbol)
+    if side:
+        filters.append(Trade.side == side.lower())
+    if start:
+        filters.append(Trade.executed_at >= start)
+    if end:
+        filters.append(Trade.executed_at <= end)
+
+    base_query = select(Trade).order_by(Trade.executed_at.desc())
+    count_query = select(func.count(Trade.id))
+    if filters:
+        base_query = base_query.where(*filters)
+        count_query = count_query.where(*filters)
+
+    offset = (page - 1) * page_size
+    result = await session.execute(base_query.offset(offset).limit(page_size))
     trades = result.scalars().all()
-    total = await session.scalar(select(func.count(Trade.id)))
-    return TradePage(items=[TradeOut.model_validate(t) for t in trades], total=total or 0)
+    total = await session.scalar(count_query) or 0
+    return TradePage(
+        items=[TradeOut.model_validate(t) for t in trades],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api import auth, bot, devices, equity, monitoring, risk, trades, websocket, users
@@ -42,14 +42,24 @@ def create_app() -> FastAPI:
             allow_methods=["*"],
             allow_headers=["*"],
         )
-    app.include_router(auth.router)
-    app.include_router(users.router)
-    app.include_router(risk.router)
-    app.include_router(bot.router)
-    app.include_router(trades.router)
-    app.include_router(equity.router)
-    app.include_router(devices.router)
-    app.include_router(monitoring.router)
+    api_v1_router = APIRouter(prefix="/api/v1")
+
+    investor_router = APIRouter(prefix="/investor", tags=["investor"])
+    investor_router.include_router(equity.router)
+    investor_router.include_router(trades.router)
+    investor_router.include_router(devices.router)
+
+    admin_router = APIRouter(prefix="/admin", tags=["admin"])
+    admin_router.include_router(users.router)
+    admin_router.include_router(risk.router)
+    admin_router.include_router(bot.router)
+    admin_router.include_router(monitoring.router)
+
+    api_v1_router.include_router(auth.router)
+    api_v1_router.include_router(investor_router)
+    api_v1_router.include_router(admin_router)
+
+    app.include_router(api_v1_router)
     app.include_router(websocket.router)
     return app
 

--- a/backend/app/schemas/trade.py
+++ b/backend/app/schemas/trade.py
@@ -3,44 +3,61 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import List
+from typing import Any, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class TradeOut(BaseModel):
+    """Serialized trade record matching the mobile contract."""
+
     id: int
     symbol: str
     side: str
-    quantity: Decimal
-    price: Decimal
+    size: Decimal
     pnl: Decimal
-    balance: Decimal
-    executed_at: datetime
-    strategy: str
+    timestamp: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def from_trade(cls, value: Any) -> Any:
+        """Normalize ORM trades into the public schema."""
+
+        # Deferred import to avoid circular dependencies at module import time.
+        from ..models.trade import Trade
+
+        if isinstance(value, Trade):
+            return {
+                "id": value.id,
+                "symbol": value.symbol,
+                "side": value.side,
+                "size": value.quantity,
+                "pnl": value.pnl,
+                "timestamp": value.executed_at,
+            }
+        return value
 
 
 class TradePage(BaseModel):
+    """Paginated trade response."""
+
     items: List[TradeOut]
+    page: int
+    page_size: int
     total: int
 
-
-class EquityPointOut(BaseModel):
-    timestamp: datetime
-    value: Decimal
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ProfitSummary(BaseModel):
-    equity: Decimal
-    pnl_absolute: Decimal
-    pnl_percent: Decimal
+    current_balance: Decimal
+    total_pl_amount: Decimal
+    total_pl_percent: Decimal
     win_rate: float
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CalendarEntry(BaseModel):
@@ -49,8 +66,7 @@ class CalendarEntry(BaseModel):
     pnl_percent: Decimal
     win_rate: Decimal
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class BalanceSnapshotOut(BaseModel):
@@ -58,8 +74,7 @@ class BalanceSnapshotOut(BaseModel):
     balance: Decimal
     equity: Decimal
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class StatusResponse(BaseModel):

--- a/tests/regression/test_backend_api_contract.py
+++ b/tests/regression/test_backend_api_contract.py
@@ -1,0 +1,172 @@
+"""Regression tests that mirror the mobile API contract."""
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from importlib import reload
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def investor_client(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Provide a TestClient seeded with representative investor data."""
+
+    db_dir = tmp_path_factory.mktemp("api_contract")
+    db_path = db_dir / "backend.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{db_path}"
+
+    from backend.app import config
+
+    config.get_settings.cache_clear()
+
+    from backend.app import database as database_module
+
+    database_module = reload(database_module)
+
+    from backend.app.services import notifications as notifications_module
+
+    notifications_module = reload(notifications_module)
+    monkeypatch.setattr(notifications_module.notification_service, "start", lambda: None)
+
+    async def _noop_shutdown() -> None:
+        return None
+
+    monkeypatch.setattr(notifications_module.notification_service, "shutdown", _noop_shutdown)
+
+    from backend.app import main as main_module
+
+    main_module = reload(main_module)
+    app = main_module.create_app()
+
+    from backend.app.security.auth import get_current_user
+    from backend.app.models.user import UserRole
+
+    dummy_user = SimpleNamespace(id="user-1", role=UserRole.VIEWER, username="viewer")
+
+    async def _current_user_override() -> SimpleNamespace:
+        return dummy_user
+
+    app.dependency_overrides[get_current_user] = _current_user_override
+
+    async def seed_data() -> None:
+        from backend.app.models.trade import BalanceSnapshot, BotState, EquityPoint, Trade
+
+        async with database_module.AsyncSessionLocal() as session:
+            now = datetime.now(timezone.utc)
+            session.add(
+                BotState(running=True, mode="paper", uptime_started_at=now - timedelta(minutes=5))
+            )
+            session.add(
+                BalanceSnapshot(
+                    balance=Decimal("10000.00"),
+                    equity=Decimal("10250.00"),
+                    timestamp=now - timedelta(minutes=1),
+                )
+            )
+            session.add_all(
+                [
+                    EquityPoint(timestamp=now - timedelta(days=2), value=Decimal("9800.00")),
+                    EquityPoint(timestamp=now - timedelta(days=1), value=Decimal("10050.50")),
+                    EquityPoint(timestamp=now, value=Decimal("10250.00")),
+                ]
+            )
+            session.add_all(
+                [
+                    Trade(
+                        symbol="AAPL",
+                        side="buy",
+                        quantity=Decimal("10"),
+                        price=Decimal("150.00"),
+                        pnl=Decimal("50.00"),
+                        balance=Decimal("10100.00"),
+                        executed_at=now - timedelta(days=1, hours=2),
+                        strategy="swing",
+                    ),
+                    Trade(
+                        symbol="AAPL",
+                        side="sell",
+                        quantity=Decimal("5"),
+                        price=Decimal("155.00"),
+                        pnl=Decimal("25.00"),
+                        balance=Decimal("10250.00"),
+                        executed_at=now - timedelta(hours=4),
+                        strategy="swing",
+                    ),
+                    Trade(
+                        symbol="TSLA",
+                        side="buy",
+                        quantity=Decimal("3"),
+                        price=Decimal("210.00"),
+                        pnl=Decimal("-15.00"),
+                        balance=Decimal("10235.00"),
+                        executed_at=now - timedelta(hours=1),
+                        strategy="scalp",
+                    ),
+                ]
+            )
+            await session.commit()
+
+    with TestClient(app) as client:
+        asyncio.run(seed_data())
+        yield client
+
+    os.environ.pop("DATABASE_URL", None)
+    config.get_settings.cache_clear()
+
+
+def test_investor_status_contract(investor_client: TestClient) -> None:
+    response = investor_client.get("/api/v1/investor/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload.keys()) == {"running", "mode", "uptime_seconds"}
+    assert payload["running"] is True
+    assert payload["mode"] == "paper"
+    assert payload["uptime_seconds"] > 0
+
+
+def test_profit_summary_contract(investor_client: TestClient) -> None:
+    response = investor_client.get("/api/v1/investor/profit")
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload.keys()) == {
+        "current_balance",
+        "total_pl_amount",
+        "total_pl_percent",
+        "win_rate",
+    }
+    as_decimal = lambda value: Decimal(str(value))
+    assert as_decimal(payload["current_balance"]) == Decimal("10250.00")
+    assert as_decimal(payload["total_pl_amount"]) == Decimal("250.00")
+    assert as_decimal(payload["total_pl_percent"]) == Decimal("2.5")
+    assert payload["win_rate"] == pytest.approx(66.6666, rel=1e-3)
+
+
+def test_equity_curve_contract(investor_client: TestClient) -> None:
+    response = investor_client.get("/api/v1/investor/equity-curve")
+    assert response.status_code == 200
+    payload = response.json()
+    assert all(isinstance(point, list) and len(point) == 2 for point in payload)
+    timestamps = [datetime.fromisoformat(point[0]) for point in payload]
+    assert timestamps == sorted(timestamps)
+
+
+def test_trades_pagination_contract(investor_client: TestClient) -> None:
+    response = investor_client.get(
+        "/api/v1/investor/trades",
+        params={"page": 1, "page_size": 2, "symbol": "AAPL"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["page_size"] == 2
+    assert payload["total"] >= 2
+    assert len(payload["items"]) == 2
+    trade = payload["items"][0]
+    assert set(trade.keys()) == {"id", "symbol", "side", "size", "pnl", "timestamp"}
+    assert trade["symbol"] == "AAPL"
+    datetime.fromisoformat(trade["timestamp"])


### PR DESCRIPTION
## Summary
- introduce an /api/v1 router hierarchy and mount investor/admin endpoints beneath it
- rename trading payload fields to match the iOS models and expose tuple-based equity curves
- expand trade pagination filters and add regression coverage that mirrors the mobile JSON contract

## Testing
- pytest tests/regression/test_backend_api_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d8499faaec832fa3c8a9be52800195