### PR TITLE
Feat: extend auth flow with profile-aware responses

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,24 +2,33 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import EmailStr
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database import get_db
 from ..models.user import User, UserRole, UserStatus
 from ..schemas.auth import (
+    AuthResponse,
+    AuthStatusResponse,
+    ForgotPasswordRequest,
     LoginRequest,
     LogoutRequest,
     RefreshRequest,
     SignupRequest,
-    TokenResponse,
+    TokenBundle,
 )
 from ..security.auth import (
     authenticate_user,
     create_tokens,
     hash_password,
+    oauth2_scheme,
     revoke_refresh_token,
+    to_user_profile,
     validate_refresh_token,
 )
 from ..security.jwt import create_access_token
@@ -30,8 +39,8 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 logger = get_logger(__name__)
 
 
-@router.post("/signup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
-async def signup(payload: SignupRequest, session: AsyncSession = Depends(get_db)) -> TokenResponse:
+@router.post("/signup", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
+async def signup(payload: SignupRequest, session: AsyncSession = Depends(get_db)) -> AuthResponse:
     existing = await session.execute(
         select(User).where((User.username == payload.username) | (User.email == payload.email))
     )
@@ -49,18 +58,18 @@ async def signup(payload: SignupRequest, session: AsyncSession = Depends(get_db)
     await session.refresh(user)
     await brevo_service.send_signup_approval_request(user.username, user.email)
     tokens = await create_tokens(session, user)
-    return TokenResponse(**tokens)
+    return AuthResponse(tokens=tokens, user=to_user_profile(user))
 
 
-@router.post("/login", response_model=TokenResponse)
-async def login(payload: LoginRequest, session: AsyncSession = Depends(get_db)) -> TokenResponse:
+@router.post("/login", response_model=AuthResponse)
+async def login(payload: LoginRequest, session: AsyncSession = Depends(get_db)) -> AuthResponse:
     user = await authenticate_user(session, payload.username, payload.password)
     tokens = await create_tokens(session, user)
-    return TokenResponse(**tokens)
+    return AuthResponse(tokens=tokens, user=to_user_profile(user))
 
 
-@router.post("/refresh", response_model=TokenResponse)
-async def refresh(payload: RefreshRequest, session: AsyncSession = Depends(get_db)) -> TokenResponse:
+@router.post("/refresh", response_model=AuthResponse)
+async def refresh(payload: RefreshRequest, session: AsyncSession = Depends(get_db)) -> AuthResponse:
     stored = await validate_refresh_token(session, payload.refresh_token)
     user = await session.get(User, stored.user_id)
     if user is None:
@@ -75,18 +84,65 @@ async def refresh(payload: RefreshRequest, session: AsyncSession = Depends(get_d
     stored_expires = stored.expires_at if stored.expires_at.tzinfo else stored.expires_at.replace(tzinfo=timezone.utc)
     expires_in = max(int((access_exp_dt - datetime.now(timezone.utc)).total_seconds()), 0)
     refresh_expires_in = max(int((stored_expires - datetime.now(timezone.utc)).total_seconds()), 0)
-    return TokenResponse(
+    tokens = TokenBundle(
         access_token=access_token,
         refresh_token=payload.refresh_token,
         token_type="bearer",
         expires_in=expires_in,
         refresh_expires_in=refresh_expires_in,
     )
+    return AuthResponse(tokens=tokens, user=to_user_profile(user))
 
 
 @router.post("/logout", status_code=status.HTTP_200_OK)
-async def logout(payload: LogoutRequest, session: AsyncSession = Depends(get_db)) -> dict[str, str]:
-    stored = await validate_refresh_token(session, payload.refresh_token)
+async def logout(
+    payload: LogoutRequest | None = None,
+    credentials: HTTPAuthorizationCredentials | None = Security(oauth2_scheme),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    refresh_token_body = payload.refresh_token if payload and payload.refresh_token else None
+    refresh_token = refresh_token_body or (credentials.credentials if credentials else None)
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Refresh token required")
+    stored = await validate_refresh_token(session, refresh_token)
     await revoke_refresh_token(session, stored.jti)
     logger.info("Refresh token revoked", extra={"jti": stored.jti})
     return {"status": "logged-out"}
+
+
+@router.get("/status", response_model=AuthStatusResponse)
+async def auth_status(
+    username: Annotated[str | None, Query(min_length=3)] = None,
+    email: Annotated[EmailStr | None, Query()] = None,
+    session: AsyncSession = Depends(get_db),
+) -> AuthStatusResponse:
+    if not username and not email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Provide a username or email",
+        )
+    query = select(User)
+    filters = []
+    if username:
+        filters.append(User.username == username)
+    if email:
+        filters.append(User.email == email)
+    condition = filters[0]
+    if len(filters) > 1:
+        condition = or_(*filters)
+    result = await session.execute(query.where(condition))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return AuthStatusResponse(status=user.status.value)
+
+
+@router.post("/forgot-password", status_code=status.HTTP_202_ACCEPTED)
+async def forgot_password(
+    payload: ForgotPasswordRequest, session: AsyncSession = Depends(get_db)
+) -> dict[str, str]:
+    result = await session.execute(select(User).where(User.email == payload.email))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    await brevo_service.send_password_reset(payload.email, payload.reset_link)
+    return {"status": "password-reset-requested"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,12 +50,13 @@ def create_app() -> FastAPI:
     investor_router.include_router(devices.router)
 
     admin_router = APIRouter(prefix="/admin", tags=["admin"])
-    admin_router.include_router(users.router)
+    admin_router.include_router(users.admin_router)
     admin_router.include_router(risk.router)
     admin_router.include_router(bot.router)
     admin_router.include_router(monitoring.router)
 
     api_v1_router.include_router(auth.router)
+    api_v1_router.include_router(users.router)
     api_v1_router.include_router(investor_router)
     api_v1_router.include_router(admin_router)
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,9 @@
 """Authentication schemas."""
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
+
+from .user import UserProfile
 
 
 class SignupRequest(BaseModel):
@@ -15,7 +17,7 @@ class LoginRequest(BaseModel):
     password: str
 
 
-class TokenResponse(BaseModel):
+class TokenBundle(BaseModel):
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
@@ -28,4 +30,18 @@ class RefreshRequest(BaseModel):
 
 
 class LogoutRequest(BaseModel):
-    refresh_token: str
+    refresh_token: str | None = None
+
+
+class AuthResponse(BaseModel):
+    tokens: TokenBundle
+    user: UserProfile
+
+
+class AuthStatusResponse(BaseModel):
+    status: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+    reset_link: str = Field(min_length=1)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -33,6 +33,17 @@ class UserOut(BaseModel):
         from_attributes = True
 
 
+class UserProfile(BaseModel):
+    id: str
+    username: str
+    email: EmailStr
+    role: UserRole
+    approval_status: UserStatus
+
+    class Config:
+        from_attributes = True
+
+
 class PasswordResetRequest(BaseModel):
     reset_link: str
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,18 +6,25 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.api import auth as auth_api
 from app.models.user import User, UserRole, UserStatus
-from app.schemas.auth import LoginRequest, LogoutRequest, RefreshRequest, SignupRequest
+from app.schemas.auth import (
+    ForgotPasswordRequest,
+    LoginRequest,
+    LogoutRequest,
+    RefreshRequest,
+    SignupRequest,
+)
 
 
 async def test_signup_pending_login_flow(
     app_client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
 ) -> None:
     async with session_factory() as session:
-        signup_tokens = await auth_api.signup(
+        signup_response = await auth_api.signup(
             SignupRequest(username="alice", email="alice@example.com", password="StrongPass123"),
             session=session,
         )
-        assert signup_tokens.access_token
+        assert signup_response.tokens.access_token
+        assert signup_response.user.username == "alice"
         user = await session.scalar(select(User).where(User.username == "alice"))
         assert user is not None
         assert user.status == UserStatus.PENDING
@@ -25,12 +32,34 @@ async def test_signup_pending_login_flow(
         user.role = UserRole.ADMIN
         await session.commit()
 
-        login_tokens = await auth_api.login(
+        login_response = await auth_api.login(
             LoginRequest(username="alice", password="StrongPass123"), session=session
         )
-        assert login_tokens.access_token
+        assert login_response.tokens.access_token
         refreshed = await auth_api.refresh(
-            RefreshRequest(refresh_token=login_tokens.refresh_token), session=session
+            RefreshRequest(refresh_token=login_response.tokens.refresh_token), session=session
         )
-        assert refreshed.access_token
-        await auth_api.logout(LogoutRequest(refresh_token=login_tokens.refresh_token), session=session)
+        assert refreshed.tokens.access_token
+        await auth_api.logout(
+            LogoutRequest(refresh_token=login_response.tokens.refresh_token), session=session
+        )
+
+
+async def test_auth_status_and_forgot_password(
+    app_client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    async with session_factory() as session:
+        signup_response = await auth_api.signup(
+            SignupRequest(username="carol", email="carol@example.com", password="StrongPass123"),
+            session=session,
+        )
+        await auth_api.auth_status(username="carol", session=session)
+        status_response = await auth_api.auth_status(email="carol@example.com", session=session)
+        assert status_response.status == signup_response.user.approval_status.value
+
+        await auth_api.forgot_password(
+            ForgotPasswordRequest(
+                email="carol@example.com", reset_link="https://example.com/reset"
+            ),
+            session=session,
+        )


### PR DESCRIPTION
## Summary
- add approval status polling, forgot password, and token revocation enhancements to the auth API
- return structured AuthResponse payloads that include serialized user profiles
- expose a `/users/me` endpoint for authenticated profiles and reorganize routers

## Testing
- `pytest tests/test_auth.py tests/test_users.py`


------
https://chatgpt.com/codex/tasks/task_e_68d84f9b347c832f9236ace463a52b7e