### PR TITLE
Feat: add notification preferences management endpoints

### DIFF
--- a/backend/app/api/devices.py
+++ b/backend/app/api/devices.py
@@ -9,6 +9,7 @@ from ..database import get_db
 from ..models.user import DeviceToken, User
 from ..schemas.user import DeviceRegisterRequest
 from ..security.auth import get_current_user
+from ..services.notifications import notification_service
 
 router = APIRouter(prefix="/devices", tags=["devices"])
 
@@ -22,11 +23,26 @@ async def register_device(
     existing = await session.scalar(select(DeviceToken).where(DeviceToken.token == payload.token))
     if existing:
         if existing.user_id != user.id:
+            previous_owner = existing.user_id
             existing.user_id = user.id
             existing.platform = payload.platform
+            existing.timezone = payload.timezone
             await session.commit()
+            notification_service.invalidate_cache(previous_owner)
+            notification_service.invalidate_cache(user.id)
+        else:
+            existing.platform = payload.platform
+            existing.timezone = payload.timezone
+            await session.commit()
+            notification_service.invalidate_cache(user.id)
         return {"status": "updated"}
-    device = DeviceToken(user_id=user.id, token=payload.token, platform=payload.platform)
+    device = DeviceToken(
+        user_id=user.id,
+        token=payload.token,
+        platform=payload.platform,
+        timezone=payload.timezone,
+    )
     session.add(device)
     await session.commit()
+    notification_service.invalidate_cache(user.id)
     return {"status": "registered"}

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -1,0 +1,76 @@
+"""Notification management endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..models.user import DeviceToken, NotificationPreference, User
+from ..schemas.user import (
+    DeviceDeregisterRequest,
+    NotificationPreferences,
+    NotificationPreferencesUpdate,
+)
+from ..security.auth import get_current_user
+from ..services.notifications import notification_service
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+async def _get_or_create_preferences(
+    session: AsyncSession, user_id: str
+) -> NotificationPreference:
+    preference = await session.get(NotificationPreference, user_id)
+    if preference is None:
+        preference = NotificationPreference(user_id=user_id)
+        session.add(preference)
+        await session.commit()
+        await session.refresh(preference)
+        notification_service.invalidate_cache(user_id)
+    return preference
+
+
+@router.get("/preferences", response_model=NotificationPreferences)
+async def get_preferences(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> NotificationPreferences:
+    preference = await _get_or_create_preferences(session, user.id)
+    merged = preference.merged_preferences()
+    return NotificationPreferences(**merged)
+
+
+@router.put("/preferences", response_model=NotificationPreferences)
+async def update_preferences(
+    payload: NotificationPreferencesUpdate,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> NotificationPreferences:
+    preference = await _get_or_create_preferences(session, user.id)
+    updates = payload.model_dump(exclude_unset=True)
+    if updates:
+        preference.preferences.update(updates)
+        await session.commit()
+        await session.refresh(preference)
+        notification_service.invalidate_cache(user.id)
+    merged = preference.merged_preferences()
+    return NotificationPreferences(**merged)
+
+
+@router.delete("/devices", status_code=status.HTTP_204_NO_CONTENT)
+async def unregister_device(
+    payload: DeviceDeregisterRequest,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> Response:
+    device = await session.scalar(
+        select(DeviceToken).where(
+            DeviceToken.user_id == user.id, DeviceToken.token == payload.token
+        )
+    )
+    if device:
+        await session.delete(device)
+        await session.commit()
+        notification_service.invalidate_cache(user.id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,18 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .api import auth, bot, devices, equity, monitoring, risk, trades, websocket, users
+from .api import (
+    auth,
+    bot,
+    devices,
+    equity,
+    monitoring,
+    notifications,
+    risk,
+    trades,
+    websocket,
+    users,
+)
 from .config import get_settings
 from .database import Base, engine
 from .services.notifications import notification_service
@@ -48,6 +59,7 @@ def create_app() -> FastAPI:
     investor_router.include_router(equity.router)
     investor_router.include_router(trades.router)
     investor_router.include_router(devices.router)
+    investor_router.include_router(notifications.router)
 
     admin_router = APIRouter(prefix="/admin", tags=["admin"])
     admin_router.include_router(users.admin_router)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -51,3 +51,23 @@ class PasswordResetRequest(BaseModel):
 class DeviceRegisterRequest(BaseModel):
     token: str = Field(max_length=512)
     platform: Literal["ios", "android"] = "ios"
+    timezone: str | None = Field(default=None, max_length=64)
+
+
+class DeviceDeregisterRequest(BaseModel):
+    token: str = Field(max_length=512)
+
+
+class NotificationPreferences(BaseModel):
+    heartbeat_push: bool = True
+    trade_alert_push: bool = True
+    system_alert_push: bool = True
+
+    class Config:
+        orm_mode = True
+
+
+class NotificationPreferencesUpdate(BaseModel):
+    heartbeat_push: bool | None = None
+    trade_alert_push: bool | None = None
+    system_alert_push: bool | None = None

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -8,12 +8,12 @@ from typing import Iterable
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database import AsyncSessionLocal
 from ..models.trade import BalanceSnapshot, BotState, SchedulerRun
-from ..models.user import DeviceToken, NotificationLog
+from ..models.user import DeviceToken, NotificationLog, NotificationPreference
 from ..utils.logger import get_logger
-from ..utils.time import now_tz
 from .push import push_service
 
 logger = get_logger(__name__)
@@ -24,6 +24,8 @@ class NotificationService:
 
     def __init__(self) -> None:
         self.scheduler = AsyncIOScheduler()
+        self._token_cache: dict[str, list[str]] = {}
+        self._preference_cache: dict[str, dict[str, bool]] = {}
         self._configure_jobs()
 
     def _configure_jobs(self) -> None:
@@ -39,16 +41,19 @@ class NotificationService:
                 latest_snapshot = await session.scalar(
                     select(BalanceSnapshot).order_by(BalanceSnapshot.timestamp.desc())
                 )
-                uptime = None
+                uptime_seconds = None
                 if bot_state and bot_state.running and bot_state.uptime_started_at:
-                    uptime = (datetime.utcnow() - bot_state.uptime_started_at).total_seconds()
+                    uptime_seconds = (datetime.utcnow() - bot_state.uptime_started_at).total_seconds()
                 balance = float(latest_snapshot.balance) if latest_snapshot else 0.0
                 equity = float(latest_snapshot.equity) if latest_snapshot else 0.0
                 message = (
                     f"Bot {'running' if bot_state and bot_state.running else 'stopped'} | "
                     f"Balance: {balance:.2f} | Equity: {equity:.2f}"
                 )
-                tokens = await self._fetch_tokens(session)
+                if uptime_seconds is not None:
+                    hours = uptime_seconds / 3600
+                    message = f"{message} | Uptime: {hours:.1f}h"
+                tokens = await self._fetch_tokens(session, "heartbeat_push")
                 await push_service.send_push(tokens, "Heartbeat", message)
                 await self._log_notification(session, None, "push", "Heartbeat", message)
                 await self._record_scheduler_run(session, "heartbeat", "success", message)
@@ -56,9 +61,34 @@ class NotificationService:
                 logger.exception("Heartbeat job failed", exc_info=exc)
                 await self._record_scheduler_run(session, "heartbeat", "error", str(exc))
 
-    async def _fetch_tokens(self, session) -> Iterable[str]:
-        result = await session.execute(select(DeviceToken.token))
-        return [row[0] for row in result.all()]
+    async def _fetch_tokens(self, session: AsyncSession, event_key: str) -> Iterable[str]:
+        token_cache = await self._load_token_cache(session)
+        preference_cache = await self._load_preference_cache(session)
+        tokens: list[str] = []
+        default_preferences = NotificationPreference.default_preferences()
+        for user_id, user_tokens in token_cache.items():
+            prefs = preference_cache.get(user_id, default_preferences)
+            if prefs.get(event_key, True):
+                tokens.extend(user_tokens)
+        return tokens
+
+    async def _load_token_cache(self, session: AsyncSession) -> dict[str, list[str]]:
+        if not self._token_cache:
+            result = await session.execute(select(DeviceToken.user_id, DeviceToken.token))
+            tokens: dict[str, list[str]] = {}
+            for user_id, token in result.all():
+                tokens.setdefault(user_id, []).append(token)
+            self._token_cache = tokens
+        return self._token_cache
+
+    async def _load_preference_cache(
+        self, session: AsyncSession
+    ) -> dict[str, dict[str, bool]]:
+        if not self._preference_cache:
+            result = await session.execute(select(NotificationPreference))
+            for preference in result.scalars():
+                self._preference_cache[preference.user_id] = preference.merged_preferences()
+        return self._preference_cache
 
     async def _log_notification(
         self,
@@ -82,6 +112,12 @@ class NotificationService:
         run = SchedulerRun(job_name=job_name, status=status, detail=detail)
         session.add(run)
         await session.commit()
+
+    def invalidate_cache(self, user_id: str | None = None) -> None:
+        """Invalidate cached token and preference snapshots."""
+
+        self._token_cache.clear()
+        self._preference_cache.clear()
 
     def start(self) -> None:
         if not self.scheduler.running:

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.api import devices as devices_api
+from app.api import notifications as notifications_api
+from app.models.user import DeviceToken, NotificationPreference, User, UserRole, UserStatus
+from app.schemas.user import (
+    DeviceDeregisterRequest,
+    DeviceRegisterRequest,
+    NotificationPreferencesUpdate,
+)
+from app.security.auth import hash_password
+from app.services.notifications import notification_service
+
+
+async def test_notification_preferences_and_devices(
+    app_client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    async with session_factory() as session:
+        notification_service.invalidate_cache()
+        user = User(
+            username="notify_user",
+            email="notify@example.com",
+            hashed_password=hash_password("StrongPass123"),
+            status=UserStatus.ACTIVE,
+            role=UserRole.VIEWER,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        prefs = await notifications_api.get_preferences(user=user, session=session)
+        assert prefs.heartbeat_push is True
+        assert prefs.trade_alert_push is True
+
+        await devices_api.register_device(
+            DeviceRegisterRequest(
+                token="device-token-1",
+                platform="ios",
+                timezone="America/Chicago",
+            ),
+            user=user,
+            session=session,
+        )
+
+        db_device = await session.scalar(
+            select(DeviceToken).where(DeviceToken.token == "device-token-1")
+        )
+        assert db_device is not None
+        assert db_device.timezone == "America/Chicago"
+
+        tokens = await notification_service._fetch_tokens(session, "heartbeat_push")
+        assert "device-token-1" in tokens
+
+        updated = await notifications_api.update_preferences(
+            NotificationPreferencesUpdate(heartbeat_push=False),
+            user=user,
+            session=session,
+        )
+        assert updated.heartbeat_push is False
+
+        stored_pref = await session.get(NotificationPreference, user.id)
+        assert stored_pref is not None
+        assert stored_pref.preferences["heartbeat_push"] is False
+
+        tokens_after_update = await notification_service._fetch_tokens(session, "heartbeat_push")
+        assert "device-token-1" not in tokens_after_update
+
+        await notifications_api.unregister_device(
+            DeviceDeregisterRequest(token="device-token-1"),
+            user=user,
+            session=session,
+        )
+
+        removed_device = await session.scalar(
+            select(DeviceToken).where(DeviceToken.token == "device-token-1")
+        )
+        assert removed_device is None
+
+        assert not notification_service._token_cache
+        assert not notification_service._preference_cache


### PR DESCRIPTION
## Summary
- add a notification preference model and expose investor APIs to view or update preferences
- capture device timezone information, support device deregistration, and invalidate notification caches
- honour per-user preferences when broadcasting heartbeat pushes and cover the flow with tests

## Testing
- pytest tests/test_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68d852638248832fac56e5132de316a7